### PR TITLE
Add proposed edits to the developer onboarding template

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -34,6 +34,16 @@ cf login -a api.fr.cloud.gov  --sso
  **Note:** As mentioned in the [Login documentation](https://developers.login.gov/testing/), the sandbox Login account is different account from your regular, production Login account. If you have not created a Login account for the sandbox before, you will need to create a new account first.
 - [ ] Setup [commit signing in Github](#setting-up-commit-signing) and with git locally.
 
+ **Note:** if you are on a mac and not able to successfully create a signed commit, getting the following error:
+```zsh
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+ You may need to add these two lines to your shell's rc file (e.g. `.bashrc` or `.zshrc`)
+```zsh
+GPG_TTY=$(tty)
+export GPG_TTY
+```
 ### Steps for the onboarder
 - [ ] Add the onboardee to cloud.gov org and relevant spaces as a SpaceDeveloper
 

--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -34,20 +34,10 @@ cf login -a api.fr.cloud.gov  --sso
  **Note:** As mentioned in the [Login documentation](https://developers.login.gov/testing/), the sandbox Login account is different account from your regular, production Login account. If you have not created a Login account for the sandbox before, you will need to create a new account first.
 - [ ] Setup [commit signing in Github](#setting-up-commit-signing) and with git locally.
 
- **Note:** if you are on a mac and not able to successfully create a signed commit, getting the following error:
-```zsh
-error: gpg failed to sign the data
-fatal: failed to write commit object
-```
- You may need to add these two lines to your shell's rc file (e.g. `.bashrc` or `.zshrc`)
-```zsh
-GPG_TTY=$(tty)
-export GPG_TTY
-```
 ### Steps for the onboarder
 - [ ] Add the onboardee to cloud.gov org and relevant spaces as a SpaceDeveloper
 
-```bash
+ ```bash
 cf set-space-role <cloud.account@email.gov> sandbox-gsa dotgov-poc SpaceDeveloper
 ```
 - [ ] Add the onboardee to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/)
@@ -80,3 +70,14 @@ gpg --armor --export <YOUR KEY>
 when setting up your key in Github.
 
 Now test commit signing is working by checking out a branch (`yourname/test-commit-signing`) and making some small change to a file. Commit the change (it should prompt you for your GPG credential) and push it to Github. Look on Github at your branch and ensure the commit is `verified`.
+
+**Note:** if you are on a mac and not able to successfully create a signed commit, getting the following error:
+```zsh
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+You may need to add these two lines to your shell's rc file (e.g. `.bashrc` or `.zshrc`)
+```zsh
+GPG_TTY=$(tty)
+export GPG_TTY
+```

--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -10,17 +10,18 @@ assignees: loganmeetsworld
 # Developer Onboarding
 
 - Onboardee: _GH handle of person being onboarded_
-- Onboarder: _GH handle of onboard buddy_ 
+- Onboarder: _GH handle of onboard buddy_
 
 ## Installation
 
 There are several tools we use locally that you will need to have.
-- [ ] [Install the cf CLI v7](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#pkg-mac) for the ability to deploy 
+- [ ] [Install the cf CLI v7](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#pkg-mac) for the ability to deploy
 - [ ] Make sure you have `gpg` >2.1.7. Run `gpg --version` to check.
 - [ ] Install the [Github CLI](https://cli.github.com/)
 
 ## Access
 
+### Steps for the onboardee
 - [ ] [Create a cloud.gov account](https://cloud.gov/docs/getting-started/accounts/)
 - [ ] Have an admin add you to the CISA Github organization and Dotgov Team.
 - [ ] Ensure you can login to your cloud.gov account via the CLI
@@ -28,11 +29,18 @@ There are several tools we use locally that you will need to have.
 cf login -a api.fr.cloud.gov  --sso
 ```
 - [ ] Have an admin add you to cloud.gov org and relevant spaces as a SpaceDeveloper
+- [ ] Have an admin add you to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/).
+
+ **Note:** As mentioned in the [Login documentation](https://developers.login.gov/testing/), the sandbox Login account is different account from your regular, production Login account. If you have not created a Login account for the sandbox before, you will need to create a new account first.
+- [ ] Setup [commit signing in Github](#setting-up-commit-signing) and with git locally.
+
+### Steps for the onboarder
+- [ ] Add the onboardee to cloud.gov org and relevant spaces as a SpaceDeveloper
+
 ```bash
 cf set-space-role <cloud.account@email.gov> sandbox-gsa dotgov-poc SpaceDeveloper
 ```
-- [ ] Add to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/)
-- [ ] Setup [commit signing in Github](#setting-up-commit-signing) and with git locally.
+- [ ] Add the onboardee to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/)
 
 
 ## Documents to Review
@@ -46,7 +54,7 @@ cf set-space-role <cloud.account@email.gov> sandbox-gsa dotgov-poc SpaceDevelope
 
 Follow the instructions [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) to generate a new GPG key and add it to your GPG keys on Github.
 
-Configure your key locally: 
+Configure your key locally:
 
 ```bash
 git config --global commit.gpgsign true


### PR DESCRIPTION
## 🗣 Description ##

This PR proposes some changes to the developer onboarding instructions based on my experience going through them. In particular, it updates the Access section.


## 💭 Motivation and context ##
There were a couple of instructions that seemed like they were steps for me to take as an onboardee, but were actually steps for the onboarder or admin. I've added subsections to clarify the actor for each step. 

The other thing that confused and tripped me up was the Login sandbox account. This was my first time using the sandbox, and I initially did not understand that this was different from my regular Login account. I think it may be helpful to add a note clarifying that.

I did run into other issues that I will note below but I'm not sure if we want to incorporate  any learnings from them into the issue template. They may be just individual troubleshooting issues. 

### Other notes / Troubleshooting
- When trying cf CLI, I got an error that my xcode dev tools were outdated and it took a little while to get the newest ones installed (had to clear up storage space and wait for download install)
- I did not have gnupg installed, and it wasn't clear right away which tool I needed to install to run the `gpg --version` command.
- When I did install gnupg, I was able to generate my keys, but then I could not actually sign a commit until I added these two lines to my `.zshrc`:
```zsh
GPG_TTY=$(tty)
export GPG_TTY
```