### PR TITLE
Include registrar in installed apps

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -78,6 +78,9 @@ INSTALLED_APPS = [
     # (and any other places you specify) into a single location
     # that can easily be served in production
     "django.contrib.staticfiles",
+
+    # let's be sure to install our own application!
+    "registrar",
 ]
 
 # Middleware are routines for processing web requests.

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -78,7 +78,6 @@ INSTALLED_APPS = [
     # (and any other places you specify) into a single location
     # that can easily be served in production
     "django.contrib.staticfiles",
-
     # let's be sure to install our own application!
     "registrar",
 ]


### PR DESCRIPTION
## 🗣 Description ##

`INSTALLED_APPS` is the list of codebases that Django knows about (typically plugins or websites).

## 💭 Motivation and context ##

Overlooked adding our own app during the last update of the settings file.