### PR TITLE
Tweak docker-compose to run migrations and use port 8080

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -28,9 +28,11 @@ services:
     stdin_open: true
     tty: true
     ports:
-      - "8080:8000"
+      - "8080:8080"
     # command: "python"
-    command: "python manage.py runserver 0.0.0.0:8000"
+    command: >
+      bash -c " python manage.py migrate &&
+      python manage.py runserver 0.0.0.0:8080"
 
   db:
     image: postgres:latest


### PR DESCRIPTION
# Tweak docker-compose file #

## 🗣 Description ##

Small changes to the `docker-compose.yml` file. First, run migrations every time the container comes up to eliminate the "you haven't run migrations" error message. Also, since the Django app announces its port number in the console, it's easier if it uses the same port number that is going to be exposed outside the container.

## 💭 Motivation and context ##

Ease the initial developer experience by making a simple `docker-compose up` easier to use.