### PR TITLE
Move to cloud.gov prototyping org with two spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -35,10 +35,10 @@ cf login -a api.fr.cloud.gov  --sso
 - [ ] Setup [commit signing in Github](#setting-up-commit-signing) and with git locally.
 
 ### Steps for the onboarder
-- [ ] Add the onboardee to cloud.gov org and relevant spaces as a SpaceDeveloper
+- [ ] Add the onboardee to cloud.gov org (cisa-getgov-prototyping) and relevant spaces (unstable) as a SpaceDeveloper
 
  ```bash
-cf set-space-role <cloud.account@email.gov> sandbox-gsa dotgov-poc SpaceDeveloper
+cf set-space-role <cloud.account@email.gov> cisa-getgov-prototyping unstable SpaceDeveloper
 ```
 - [ ] Add the onboardee to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/)
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,8 +3,7 @@ name: Build and deploy
 # This workflow runs on pushes to main (typically,
 # a merged pull request) and on pushes of tagged commits.
 
-# Pushes to main will deploy to Unstable; tagged commits
-# will deploy to Staging
+# Pushes to main will deploy to Staging
 
 on:
   push:
@@ -17,9 +16,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-unstable:
+  deploy-staging:
     # if this job runs on a branch, we deduce that code
-    # has been pushed to main and should be deployed to unstable
+    # has been pushed to main and should be deployed to staging
     if: ${{ github.ref_type == 'branch' }}
     runs-on: ubuntu-latest
     steps:
@@ -30,13 +29,8 @@ jobs:
         env:
           DEPLOY_NOW: thanks
         with:
-          cf_username: ${{ secrets.CF_USERNAME }}
-          cf_password: ${{ secrets.CF_PASSWORD }}
-          cf_org: sandbox-gsa
-          cf_space: dotgov-poc
-          push_arguments: "-f ops/manifests/manifest-unstable.yaml"
-
-  # deploy-staging:
-  #   # if this job runs on a tag, we deduce that code
-  #   # has been tagged for release and should be deployed to staging
-  #   if: ${{ github.ref_type == 'tag' }}
+          cf_username: ${{ secrets.CF_STAGING_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
+          cf_org: cisa-getgov-prototyping
+          cf_space: staging
+          push_arguments: "-f ops/manifests/manifest-staging.yaml"

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -3,7 +3,7 @@ name: Run Migrations
 # This workflow can be run from the CLI
 #     gh workflow run migrate.yaml -f environment=sandbox
 # OR
-#     cf run-task getgov-unstable --wait \
+#     cf run-task getgov-staging --wait \
 #        --command 'python manage.py migrate' --name migrate
 
 on:
@@ -13,22 +13,19 @@ on:
         type: choice
         description: Where should we run migrations
         options:
-        - unstable
         - staging
 
 jobs:
-  migrate-unstable:
-    if: ${{ github.event.inputs.environment == 'unstable' }}
+  migrate-staging:
+    if: ${{ github.event.inputs.environment == 'staging' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Run Django migrations for unstable
+      - name: Run Django migrations for staging
         uses: 18f/cg-deploy-action@main
         with:
           cf_username: ${{ secrets.CF_USERNAME }}
           cf_password: ${{ secrets.CF_PASSWORD }}
-          cf_org: sandbox-gsa
-          cf_space: dotgov-poc
-          full_command: "cf run-task getgov-unstable --wait --command 'python manage.py migrate' --name migrate"
+          cf_org: cisa-getgov-prototyping
+          cf_space: staging
+          full_command: "cf run-task getgov-staging --wait --command 'python manage.py migrate' --name migrate"
 
-  # migrate:
-  #   if: ${{ github.event.inputs.environment == 'staging' }}

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -28,8 +28,18 @@ cf target -o <ORG> -s <SPACE>
 
 ## Database
 
-In sandbox, created with `cf create-service aws-rds micro-psql getgov-database`.
+In sandbox, created with `cf create-service aws-rds micro-psql getgov-ENV-database`.
 
 Binding the database in `manifest-<ENVIRONMENT>.json` automatically inserts the connection string into the environment as `DATABASE_URL`.
 
 [Cloud.gov RDS documentation](https://cloud.gov/docs/services/relational-database/).
+
+# Deploy
+
+We have two environments: `unstable` and `staging`. Developers can deploy locally to unstable whenever they want. However, only our CD service can deploy to `staging`, and it does so on every commit to `main`. This is to ensure that we have a "golden" environment to point to, and can still test things out in an unstable space. To deploy locally to `unstable`: 
+
+```bash
+cf target -o cisa-getgov-prototyping -s unstable
+cf push getgov-unstable -f ops/manifests/manifest-unstable.yaml
+cf run-task getgov-unstable --command 'python manage.py migrate' --name migrate
+```

--- a/docs/operations/runbooks/rotate_application_secrets.md
+++ b/docs/operations/runbooks/rotate_application_secrets.md
@@ -27,7 +27,7 @@ To rotate secrets, create a new `credentials-<ENVIRONMENT>.json` file, upload it
 Example:
 
 ```bash
-cf uups getgov-credentials -p credentials-unstable.json
+cf cups getgov-credentials -p credentials-unstable.json
 cf restage getgov-unstable --strategy rolling
 ```
 

--- a/ops/manifests/manifest-staging.yaml
+++ b/ops/manifests/manifest-staging.yaml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: getgov-unstable
+- name: getgov-staging
   buildpacks:
     - python_buildpack
   path: ../../src
@@ -17,7 +17,7 @@ applications:
     # Tell Django where to find its configuration
     DJANGO_SETTINGS_MODULE: registrar.config.settings
   routes:
-    - route: getgov-unstable.app.cloud.gov
+    - route: getgov-staging.app.cloud.gov
   services:
   - getgov-credentials
-  - getgov-unstable-database
+  - getgov-staging-database

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -388,6 +388,7 @@ SECURE_SSL_REDIRECT = True
 # web server configurations.
 ALLOWED_HOSTS = [
     "getgov-unstable.app.cloud.gov",
+    "getgov-staging.app.cloud.gov",
     "get.gov",
 ]
 


### PR DESCRIPTION
## 🗣 Description ##

This moves us to our cloud.gov prototyping org with new spaces: `unstable` and `staging`. I've clarified rules we talked about where `unstable` is only used by developers (removed from our CD) to test things out and `staging` is deployed to on `main`. 

## 💭 Motivation and context ##

The prototyping org allows us to have multiple environments to test out this workflow. Fixes #98. I have also added all our developers as SpaceDevelopers to the `unstable` space. However, no one has developer access to the `staging` space besides our Github action. I have rotated these secrets, and removed all artifacts from the previous org/space.

## Notes ##

Right now I'm running into an issue deploying these where the apps crash trying to talk to RDS. I'll work through that with the team before merging and make sure both spaces get a deployment of the app. Currently our app is pulled down from the previous space.