### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 ### Project specific ###
 
 docs/research/data/**
-static/
+**/assets/*
+!**/assets/sass/
 public/
 credentials*
 


### PR DESCRIPTION
## 🗣 Description ##

Add Django's `assets` directory to `.gitignore`.

## 💭 Motivation and context ##

The purpose of a `.gitignore` file is to prevent files from being added to the index by accident. Asset files, which are typically larger files and may also be auto-generated, are prime candidates of this feature.

The `sass` subdirectory is re-included, due to it containing actual source code which should always be committed.