### PR TITLE
Add asset compilation and collection before deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - ik/stable-uswds-assets
 
     tags:
       - v*

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - ik/stable-uswds-assets
 
     tags:
       - v*
@@ -24,6 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Compile USWDS assets
+        working-directory: ./src
+        run: |
+          docker compose run node npm install && 
+          docker compose run node npx gulp compile && 
+          docker compose run node npx gulp 
       - name: Deploy to cloud.gov sandbox
         uses: 18f/cg-deploy-action@main
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,8 +29,11 @@ jobs:
         working-directory: ./src
         run: |
           docker compose run node npm install && 
-          docker compose run node npx gulp compile && 
-          docker compose run node npx gulp 
+          docker compose run node npx gulp copyAssets &&
+          docker compose run node npx gulp compile 
+      - name: Collect static assets 
+        working-directory: ./src
+        run: docker compose run app python manage.py collectstatic
       - name: Deploy to cloud.gov sandbox
         uses: 18f/cg-deploy-action@main
         env:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -36,9 +36,15 @@ Binding the database in `manifest-<ENVIRONMENT>.json` automatically inserts the 
 
 # Deploy
 
-We have two environments: `unstable` and `staging`. Developers can deploy locally to unstable whenever they want. However, only our CD service can deploy to `staging`, and it does so on every commit to `main`. This is to ensure that we have a "golden" environment to point to, and can still test things out in an unstable space. To deploy locally to `unstable`:
+We have two environments: `unstable` and `staging`. Developers can deploy locally to unstable whenever they want. However, only our CD service can deploy to `staging`, and it does so on every commit to `main`. This is to ensure that we have a "golden" environment to point to, and can still test things out in an unstable space. You should make sure all of the USWDS assets are compiled and collected before deploying to unstable. To deploy locally to `unstable`:
 
 ```bash
+# Compile and collect the assets
+docker-compose run node npx gulp compile
+docker-compose run node npx gulp copyAssets
+docker-compose run app ./manage.py collectstatic
+
+# Deploy to unstable
 cf target -o cisa-getgov-prototyping -s unstable
 cf push getgov-unstable -f ops/manifests/manifest-unstable.yaml
 cf run-task getgov-unstable --command 'python manage.py migrate' --name migrate

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -28,6 +28,7 @@ uswds.paths.dist.img = ASSETS_DIR + 'img';
  * Add as many as you need
  */
 
+exports.default = uswds.compile;
 exports.init = uswds.init;
 exports.compile = uswds.compile;
 exports.watch = uswds.watch;


### PR DESCRIPTION
## 🗣 Description ##

This PR adds two steps to the deploy GitHub Action that compile the USWDS assets and collect them into the `/public` folder using our docker container before deploying them to staging. By using the GH action and the docker container we can avoid having to run `collectstatic` on the server upon deploying. 

This closes #120 

https://getgov-staging.app.cloud.gov/


