### PR TITLE
Add build and deploy scripts

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -49,9 +49,10 @@ cf target -o cisa-getgov-prototyping -s unstable
 cf push getgov-unstable -f ops/manifests/manifest-unstable.yaml
 cf run-task getgov-unstable --command 'python manage.py migrate' --name migrate
 ```
+Alternatively, you could run the `deploy.sh` script in the `/src` directory to build the assets and deploy to `unstable`. Similarly, you could run `bash.sh` script to just compile and collect the assets without deploying.
 
 
 ## Serving static assets
 We are using [WhiteNoise](http://whitenoise.evans.io/en/stable/index.html) plugin to serve our static assets on cloud.gov. This plugin is added to the `MIDDLEWARE` list in our apps `settings.py`.
 
-Note that it’s a good idea to run `collectstatic` locally or in the docker container before pushing files up to `unstable`. This is because `collectstatic` relies on timestamps when deciding to whether to overwrite the existing assets in `/public`. Due the way files are uploaded, the compiled css in the `/assets/css` folder on `unstable` will have a slightly earlier timestamp than the files in `/public/css`, and consequently running `collectstatic` on`unstable` will not update `public/css` as you may expect.
+Note that it’s a good idea to run `collectstatic` locally or in the docker container before pushing files up to `unstable`. This is because `collectstatic` relies on timestamps when deciding to whether to overwrite the existing assets in `/public`. Due the way files are uploaded, the compiled css in the `/assets/css` folder on `unstable` will have a slightly earlier timestamp than the files in `/public/css`, and consequently running `collectstatic` on`unstable` will not update `public/css` as you may expect. For convenience, both the `deploy.sh` and `build.sh` scripts will take care of that. 

--- a/ops/README.md
+++ b/ops/README.md
@@ -3,4 +3,4 @@
 
 This directory contains files related to deploying or running the application(s).
 
-Documentation is in [docs/ops](../docs/ops).
+Documentation is in [docs/ops](../docs/operations/).

--- a/ops/scripts/build.sh
+++ b/ops/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Compile assets
+docker compose run node npx gulp compile;
+docker compose run node npx gulp copyAssets;
+
+# Collect assets
+docker compose run app python manage.py collectstatic --noinput

--- a/ops/scripts/deploy.sh
+++ b/ops/scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Compile and collect static assets
+../ops/scripts/build.sh
+
+# Deploy to unstable 
+cf target -o cisa-getgov-prototyping -s unstable
+cf push getgov-unstable -f ../ops/manifests/manifest-unstable.yaml
+
+cf run-task getgov-unstable --command 'python manage.py migrate' --name migrate

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,0 +1,1 @@
+../ops/scripts/build.sh

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1,0 +1,1 @@
+../ops/scripts/deploy.sh

--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -26,3 +26,7 @@ i.e.
 p {
   color: color('blue-10v');
 }
+
+footer p {
+  color: color('blue-70v');
+}

--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -28,5 +28,5 @@ p {
 }
 
 footer p {
-  color: color('blue-70v');
+  color: color('blue-50v');
 }

--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -27,6 +27,3 @@ p {
   color: color('blue-10v');
 }
 
-footer p {
-  color: color('blue-50v');
-}

--- a/src/run.sh
+++ b/src/run.sh
@@ -15,4 +15,7 @@ else
   fi
 fi
 
+# Make sure that django's `collectstatic` has been run locally before pushing up to unstable,
+# so that the styles and static assets to show up correctly on unstable.
+
 gunicorn registrar.config.wsgi -t 60

--- a/src/run.sh
+++ b/src/run.sh
@@ -15,5 +15,4 @@ else
   fi
 fi
 
-python manage.py collectstatic --settings=registrar.config.settings --noinput
 gunicorn registrar.config.wsgi -t 60


### PR DESCRIPTION
## 🗣 Description ##

This PR adds a build and deploy scripts as suggested in the discussion in #123. 

The build script compiles the css, copies over the static assets, and collects into the `/public` folder. The deploy script runs the build script and then pushes the up the files to `unstable`.

The PR also updates the corresponding documentation. 

## 💭 Motivation and context ##
These two scripts make it easier to compile the assets and deploy them to unstable. They also remove the need to run `collectstatic` on the server.  In the future we could add the `build.sh` script to the deploy GitHub Action. 

## 🤔 Question ##
I created a symlink in the `src` folder to link to the scripts in the `ops/scripts` folder. This is because the paths used in the scripts assume they are run from the `src` folder, and as a convenience when trying to run them from that src (i.e. so that one doesn't have to type `../ops/<script>`.  Is there any issue with that? Should I use a different path in the scripts?