### PR TITLE
Fix deploy issue with debug_toolbar URLs

### DIFF
--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -15,6 +15,15 @@ urlpatterns = [
     path("health/", health.health),
     path("edit_profile/", profile.edit_profile, name="edit-profile"),
     path("openid/", include("djangooidc.urls")),
-    # these views respect the DEBUG setting
-    path("__debug__/", include("debug_toolbar.urls")),
 ]
+
+# we normally would guard these with `if settings.DEBUG` but tests run with
+# DEBUG = False even when these apps have been loaded because settings.DEBUG
+# was actually True. Instead, let's add these URLs any time we are able to
+# import the debug toolbar package.
+try:
+    import debug_toolbar
+
+    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
+except ImportError:
+    pass

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1,8 +1,6 @@
 from django.test import Client, TestCase
 from django.contrib.auth import get_user_model
 
-from registrar.models import UserProfile
-
 
 class HealthTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
# Fix deploy issue with debug_toolbar

## 🗣 Description ##

We have an issue with our use of debug_toolbar. It is installed as a "dev" dependency by Pip, so it isn't present in our production cloud.gov deploys. We could include it conditionally in our app by checking for `settings.DEBUG` except that breaks the test suite because tests artificially run with `DEBUG=False`. This uses a try/except block to load the URLs for the debug toolbar whenever the package is installed.

## 💭 Motivation and context ##

Trying to load the debug_toolbar URLs when the package is not installed is breaking the current deploy to staging.