### PR TITLE
Change SESSION_COOKIE_SAMESITE to Lax

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -529,8 +529,9 @@ SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_NAME = "JSESSIONID"
 
 # Prevents session cookie from being sent if the user
-# is coming to our site from an external page.
-SESSION_COOKIE_SAMESITE = "Strict"
+# is coming to our site from an external page via
+# "risky" paths, i.e. POST requests
+SESSION_COOKIE_SAMESITE = "Lax"
 
 # instruct browser to only send cookie via HTTPS
 SESSION_COOKIE_SECURE = True

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -528,9 +528,9 @@ SESSION_COOKIE_HTTPONLY = True
 # are we a spring boot application? who knows!
 SESSION_COOKIE_NAME = "JSESSIONID"
 
-# Prevents session cookie from being sent if the user
-# is coming to our site from an external page via
-# "risky" paths, i.e. POST requests
+# Allows session cookie to be sent if the user
+# is coming to our site from an external page
+# unless it is via "risky" paths, i.e. POST requests
 SESSION_COOKIE_SAMESITE = "Lax"
 
 # instruct browser to only send cookie via HTTPS


### PR DESCRIPTION
## 🗣 Description ##

This changes the setting which controls whether the session cookie is sent in cross-site requests. "Lax" is the default and prevents some (but not all) session cookie cross-site requests.

https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-SESSION_COOKIE_SAMESITE

## 💭 Motivation and context ##

This change is required, because users returning from logging in via Login.gov will fail to complete the login process because the login callback (the view to which they are redirected by Login.gov) will not recognize them, due to the lack of a session id cookie.

@neilmb posited that Lax is preferred behavior:

> If someone was logged in with their browser and they got a link in Teams from a colleague, I would want their logged-in cookie to work to get them to that URL.

The most important consequence of this is to ensure that no parameters from a GET request will modify the database. This is simple in forms, because form data is customarily sent by POST, but may need extra attention in areas like search, where search queries are often sent as GET request for bookmarkablity and may trigger data writes as side-effects.