### PR TITLE
Include schemes in manifest base URLs

### DIFF
--- a/ops/manifests/manifest-staging.yaml
+++ b/ops/manifests/manifest-staging.yaml
@@ -17,7 +17,7 @@ applications:
     # Tell Django where to find its configuration
     DJANGO_SETTINGS_MODULE: registrar.config.settings
     # Tell Django where it is being hosted
-    DJANGO_BASE_URL: getgov-staging.app.cloud.gov
+    DJANGO_BASE_URL: https://getgov-staging.app.cloud.gov
     # Tell Django how much stuff to log
     DJANGO_LOG_LEVEL: INFO
   routes:

--- a/ops/manifests/manifest-unstable.yaml
+++ b/ops/manifests/manifest-unstable.yaml
@@ -17,7 +17,7 @@ applications:
     # Tell Django where to find its configuration
     DJANGO_SETTINGS_MODULE: registrar.config.settings
     # Tell Django where it is being hosted
-    DJANGO_BASE_URL: getgov-unstable.app.cloud.gov
+    DJANGO_BASE_URL: https://getgov-unstable.app.cloud.gov
     # Tell Django how much stuff to log
     DJANGO_LOG_LEVEL: INFO
   routes:


### PR DESCRIPTION
# Use correct base URLs

## 🗣 Description ##

We include the scheme in our `DJANGO_BASE_URL` environment variable to allow for `http` for local development as opposed to `https` for our Cloud.gov environments. This updates the manifests to match.

## 💭 Motivation and context ##

Makes the `unstable` and hopefully the `staging` Login.gov interaction work.