### PR TITLE
be more explicit in rotation docs about what cups and uups stands for

### DIFF
--- a/docs/operations/runbooks/rotate_application_secrets.md
+++ b/docs/operations/runbooks/rotate_application_secrets.md
@@ -20,14 +20,14 @@ Where `credentials-<ENVIRONMENT>.json` looks like:
 
 You can see the current environment with `cf env <APP>`, for example `cf env getgov-unstable`.
 
-The command `cups` stands for [create user provided service](https://docs.cloudfoundry.org/devguide/services/user-provided.html). User provided services are the way currently recommended by Cloud.gov for deploying secrets. The user provided service is bound to the application in `manifest-<ENVIRONMENT>.json`.
+The commands `cups` and `uups` stand for [`create user provided service`](https://docs.cloudfoundry.org/devguide/services/user-provided.html) and `update user provided service`. User provided services are the way currently recommended by Cloud.gov for deploying secrets. The user provided service is bound to the application in `manifest-<ENVIRONMENT>.json`.
 
 To rotate secrets, create a new `credentials-<ENVIRONMENT>.json` file, upload it, then restage the app.
 
 Example:
 
 ```bash
-cf cups getgov-credentials -p credentials-unstable.json
+cf update-user-provided-service getgov-credentials -p credentials-unstable.json
 cf restage getgov-unstable --strategy rolling
 ```
 


### PR DESCRIPTION
## 🗣 Description ##

Updates the docs to use a more explicit command for updating application secrets. 