### PR TITLE
Add .cfignore

### DIFF
--- a/src/.cfignore
+++ b/src/.cfignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## 🗣 Description ##

What it says in the title

## 💭 Motivation and context ##

Because `cf push` was trying to upload my whole `node_modules` folder.

It also took me a hot minute to realize that `.cfignore` had to go in `src/` rather than in the root of the repository where I run `cf push`.