### PR TITLE
Use a demo site banner to avoid confusion

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -146,7 +146,6 @@ STATICFILES_DIRS = [
     BASE_DIR / "assets",
 ]
 
-# TODO: decide on template engine and document in ADR
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -168,10 +167,15 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "registrar.context_processors.language_code",
                 "registrar.context_processors.canonical_path",
+                "registrar.context_processors.is_demo_site",
             ],
         },
     },
 ]
+
+# IS_DEMO_SITE controls whether or not we show our big red "TEST SITE" banner
+# underneath the "this is a real government website" banner.
+IS_DEMO_SITE = True
 
 # endregion
 # region: Database----------------------------------------------------------###

--- a/src/registrar/context_processors.py
+++ b/src/registrar/context_processors.py
@@ -21,3 +21,13 @@ def canonical_path(request):
     template itself, so we do it here and pass the information on.
     """
     return {"CANONICAL_PATH": request.build_absolute_uri(request.path)}
+
+
+def is_demo_site(request):
+    """Add a boolean if this is a demo site.
+
+    To be able to render or not our "demo site" banner, we need a context
+    variable for the template that indicates if this banner should or
+    should not appear.
+    """
+    return {"IS_DEMO_SITE": settings.IS_DEMO_SITE}

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -106,7 +106,7 @@
   {% if IS_DEMO_SITE %}
     <section
     class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-icon"
-    aria-label="Site alert,,,,,"
+    aria-label="Site alert"
     >
       <div class="usa-alert">
         <div class="usa-alert__body">

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -103,6 +103,20 @@
       </div>
     </div>
   </section>
+  {% if IS_DEMO_SITE %}
+    <section
+    class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-icon"
+    aria-label="Site alert,,,,,"
+    >
+      <div class="usa-alert">
+        <div class="usa-alert__body">
+          <p class="usa-alert__text">
+            <strong>TEST SITE</strong> - Do not use real personal information. Demo purposes only.
+          </p>
+        </div>
+      </div>
+    </section>
+  {% endif %}
 
 
   {% block usa_overlay %}<div class="usa-overlay"></div>{% endblock %}


### PR DESCRIPTION
# Add a demo site banner so we don't claim to be a real government site #

## 🗣 Description ##

As we add more functionality to our development sites running on cloud.gov, we need an indication that this is not the actual site for registering dotgov domains. This adds a configuration setting `IS_DEMO_SITE` and a template variable to control whether or not we include a big red banner that says "TEST SITE".

![Screen Shot 2022-10-28 at 14 37 28](https://user-images.githubusercontent.com/443389/198718506-060065b9-419d-461c-8aaa-1c32a51618d8.png)

Currently we only have an unstable and staging environment so this config variable is always `True`. When we get close to having a production site, we will have to put in a place a method for modifying this setting to make it `False` on the production app.

## 💭 Motivation and context ##

This closes #152.