### PR TITLE
Pin Python image to 3.10

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3
+FROM python:3.10
+
+# Python 3.11 introduces a bug in oic package, fyi - Oct 31, 2022
 
 RUN apt-get update && apt-get install -y postgresql-client
 


### PR DESCRIPTION
## 🗣 Description ##

Due to some change made in Python 3.11, oic package no longer works. Pinning our Dockerfile to match our Cloud.gov runtime.txt until an upstream fix is merged.