### PR TITLE
Add JavaScript to check domain availability

### DIFF
--- a/src/registrar/templates/application_contact.html
+++ b/src/registrar/templates/application_contact.html
@@ -23,7 +23,7 @@ of a larger entity. If so, enter information about your part of the larger entit
 
   <fieldset class="usa-fieldset">
     {{ wizard.form.street_address|add_label_class:"usa-label" }}
-    {{ wizard.form.street_address|add_class:"usa-input" }}
+    {{ wizard.form.street_address|add_class:"usa-input"|attr:"validate:domain" }}
   </fieldset>
 
   {% if wizard.steps.prev %}


### PR DESCRIPTION
## 🗣 Description ##

When a user types characters into the domain validation box, this code waits until they appear to be done typing and then calls the API to determine availability.

For testing/demo purposes, I have transformed the existing "Street address" field into a domain validator.

![image](https://user-images.githubusercontent.com/15718530/199985118-cbd984b1-0ff6-4b43-a4b8-7a173847a661.png)

This PR does not include any styling elements or user messaging, aside from the bare minimum to make the code functional.

## 💭 Motivation and context ##

This is one possible solution to doing the frontend domain validation check. Another way, likely simpler and with better user experience is to place an explicit button to allow checking.

Nevertheless, this implementation includes some JavaScript code (and patterns) which may be useful for validation elsewhere in the application.

It may, at some point, be worthwhile to write tests for our JavaScript. That will be no simple undertaking however, because they can only be run e2e (in other words, with Django running, similar to how pa11y works). In the meantime, I have been concentrating effort on ensuring that the pages are _fully functional_ even if the user has JavaScript disabled or the scripts crash/fail to load.

Closes #223 