### PR TITLE
Show questions conditionally based on organization type

### DIFF
--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -10,12 +10,14 @@ from django.urls import include, path
 from django.views.generic import RedirectView
 
 from registrar.views import health, index, profile, whoami
-from registrar.forms import ApplicationWizard
+from registrar.forms import ApplicationWizard, WIZARD_CONDITIONS
 from api.views import available
 
 APPLICATION_URL_NAME = "application_step"
 application_wizard = ApplicationWizard.as_view(
-    url_name=APPLICATION_URL_NAME, done_step_name="finished"
+    url_name=APPLICATION_URL_NAME,
+    done_step_name="finished",
+    condition_dict=WIZARD_CONDITIONS,
 )
 
 urlpatterns = [

--- a/src/registrar/forms/__init__.py
+++ b/src/registrar/forms/__init__.py
@@ -1,4 +1,4 @@
 from .edit_profile import EditProfileForm
-from .application_wizard import ApplicationWizard
+from .application_wizard import ApplicationWizard, WIZARD_CONDITIONS
 
-__all__ = ["EditProfileForm", "ApplicationWizard"]
+__all__ = ["EditProfileForm", "ApplicationWizard", "WIZARD_CONDITIONS"]

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -4,8 +4,6 @@ from __future__ import annotations  # allows forward references in annotations
 
 import logging
 
-from typing import Union
-
 from django import forms
 from django.shortcuts import render
 

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -4,6 +4,8 @@ from __future__ import annotations  # allows forward references in annotations
 
 import logging
 
+from typing import Union
+
 from django import forms
 from django.shortcuts import render
 
@@ -72,7 +74,7 @@ class OrganizationElectionForm(RegistrarForm):
                 (False, "No"),
             ],
         ),
-        required=False
+        required=False,
     )
 
 
@@ -298,12 +300,12 @@ def _get_organization_type(wizard: ApplicationWizard) -> Union[str, None]:
     return None
 
 
-def show_organization_federal(wizard: ApplicationWizard) -> Bool:
+def show_organization_federal(wizard: ApplicationWizard) -> bool:
     """Show this step if the answer to the first question was "federal"."""
     return _get_organization_type(wizard) == "Federal"
 
 
-def show_organization_election(wizard: ApplicationWizard) -> Bool:
+def show_organization_election(wizard: ApplicationWizard) -> bool:
     """Show this step if the answer to the first question implies it.
 
     This shows for answers that aren't "Federal" or "Interstate".

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -289,38 +289,11 @@ TITLES = {
 }
 
 
-def _get_organization_type(wizard: ApplicationWizard) -> Union[str, None]:
-    """Extract the answer to the organization type question from the wizard."""
-    # using the step data from the storage is a workaround for this
-    # bug in django-formtools version 2.4
-    # https://github.com/jazzband/django-formtools/issues/220
-    type_data = wizard.storage.get_step_data("organization_type")
-    if type_data:
-        return type_data.get("organization_type-organization_type")
-    return None
-
-
-def show_organization_federal(wizard: ApplicationWizard) -> bool:
-    """Show this step if the answer to the first question was "federal"."""
-    return _get_organization_type(wizard) == "Federal"
-
-
-def show_organization_election(wizard: ApplicationWizard) -> bool:
-    """Show this step if the answer to the first question implies it.
-
-    This shows for answers that aren't "Federal" or "Interstate".
-    """
-    type_answer = _get_organization_type(wizard)
-    if type_answer and type_answer not in ("Federal", "Interstate"):
-        return True
-    return False
-
-
 # We can use a dictionary with step names and callables that return booleans
 # to show or hide particular steps based on the state of the process.
 WIZARD_CONDITIONS = {
-    "organization_federal": show_organization_federal,
-    "organization_election": show_organization_election,
+    "organization_federal": DomainApplication.show_organization_federal,
+    "organization_election": DomainApplication.show_organization_election,
 }
 
 

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -1,3 +1,6 @@
+
+from __future__ import annotations
+
 from django.db import models
 from django_fsm import FSMField, transition  # type: ignore
 
@@ -5,6 +8,10 @@ from .utility.time_stamped_model import TimeStampedModel
 from .contact import Contact
 from .user import User
 from .website import Website
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+	from ..forms.application_wizard import ApplicationWizard
 
 
 class DomainApplication(TimeStampedModel):
@@ -225,3 +232,37 @@ class DomainApplication(TimeStampedModel):
         # if no exception was raised, then we don't need to do anything
         # inside this method, keep the `pass` here to remind us of that
         pass
+
+    # ## Form policies ###
+    #
+    # These methods control what questions need to be answered by applicants
+    # during the application flow. They are policies about the application so
+    # they appear here.
+
+    @staticmethod
+    def _get_organization_type(wizard: ApplicationWizard) -> Union[str, None]:
+        """Extract the answer to the organization type question from the wizard."""
+        # using the step data from the storage is a workaround for this
+        # bug in django-formtools version 2.4
+        # https://github.com/jazzband/django-formtools/issues/220
+        type_data = wizard.storage.get_step_data("organization_type")
+        if type_data:
+            return type_data.get("organization_type-organization_type")
+        return None
+
+    @staticmethod
+    def show_organization_federal(wizard: ApplicationWizard) -> bool:
+        """Show this step if the answer to the first question was "federal"."""
+        return DomainApplication._get_organization_type(wizard) == "Federal"
+
+    @staticmethod
+    def show_organization_election(wizard: ApplicationWizard) -> bool:
+        """Show this step if the answer to the first question implies it.
+
+        This shows for answers that aren't "Federal" or "Interstate".
+        """
+        type_answer = DomainApplication._get_organization_type(wizard)
+        if type_answer and type_answer not in ("Federal", "Interstate"):
+            return True
+        return False
+

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 from django.db import models
@@ -9,9 +8,10 @@ from .contact import Contact
 from .user import User
 from .website import Website
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
+
 if TYPE_CHECKING:
-	from ..forms.application_wizard import ApplicationWizard
+    from ..forms.application_wizard import ApplicationWizard
 
 
 class DomainApplication(TimeStampedModel):
@@ -265,4 +265,3 @@ class DomainApplication(TimeStampedModel):
         if type_answer and type_answer not in ("Federal", "Interstate"):
             return True
         return False
-

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django_webtest import WebTest  # type: ignore
 
 from registrar.models import DomainApplication
+from registrar.forms.application_wizard import TITLES
 
 
 class TestViews(TestCase):
@@ -96,15 +97,6 @@ class FormTests(TestWithUser, WebTest):
         result = page.form.submit()
         self.assertIn("What kind of government organization do you represent?", result)
 
-    def test_application_form_organization(self):
-        # 302 redirect to the first form
-        page = self.app.get(reverse("application")).follow()
-        form = page.form
-        form["organization_type-organization_type"] = "Federal"
-        result = page.form.submit().follow()
-        # Got the next form page
-        self.assertContains(result, "contact information")
-
     def test_application_form_submission(self):
         """Can fill out the entire form and submit.
         As we add additional form pages, we need to include them here to make
@@ -130,10 +122,10 @@ class FormTests(TestWithUser, WebTest):
         self.assertEquals(type_result.status_code, 302)
         self.assertEquals(type_result["Location"], "/register/organization_federal/")
 
-        # TODO: In the future this should be conditionally dispalyed based on org type
 
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         federal_page = type_result.follow()
         federal_form = federal_page.form
         federal_form["organization_federal-federal_type"] = "Executive"
@@ -144,26 +136,12 @@ class FormTests(TestWithUser, WebTest):
 
         self.assertEquals(federal_result.status_code, 302)
         self.assertEquals(
-            federal_result["Location"], "/register/organization_election/"
-        )
-
-        # ---- ELECTION BOARD BRANCH PAGE  ----
-        # Follow the redirect to the next form page
-        election_page = federal_result.follow()
-        election_form = election_page.form
-        election_form["organization_election-is_election_board"] = True
-
-        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        election_result = election_form.submit()
-
-        self.assertEquals(election_result.status_code, 302)
-        self.assertEquals(
-            election_result["Location"], "/register/organization_contact/"
+            federal_result["Location"], "/register/organization_contact/"
         )
 
         # ---- ORG CONTACT PAGE  ----
         # Follow the redirect to the next form page
-        org_contact_page = election_result.follow()
+        org_contact_page = federal_result.follow()
         org_contact_form = org_contact_page.form
         org_contact_form["organization_contact-organization_name"] = "Testorg"
         org_contact_form["organization_contact-address_line1"] = "address 1"
@@ -322,3 +300,69 @@ class FormTests(TestWithUser, WebTest):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         final_result = review_result.follow()
         self.assertContains(final_result, "Thank you for your domain request")
+
+    def test_application_form_conditional_federal(self):
+        """Federal branch question is shown for federal organizations."""
+        type_page = self.app.get(reverse("application")).follow()
+        # django-webtest does not handle cookie-based sessions well because it keeps
+        # resetting the session key on each new request, thus destroying the concept
+        # of a "session". We are going to do it manually, saving the session ID here
+        # and then setting the cookie on each request.
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+        # ---- TYPE PAGE  ----
+
+        # the conditional step titles shouldn't appear initially
+        self.assertNotContains(type_page, TITLES["organization_federal"])
+        self.assertNotContains(type_page, TITLES["organization_election"])
+        type_form = type_page.form
+        type_form["organization_type-organization_type"] = "Federal"
+
+        # set the session ID before .submit()
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        type_result = type_form.submit()
+
+        # the post request should return a redirect to the federal branch
+        # question
+        self.assertEquals(type_result.status_code, 302)
+        self.assertEquals(type_result["Location"], "/register/organization_federal/")
+
+        # and the step label should appear in the sidebar of the resulting page
+        # but the step label for the elections page should not appear
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        federal_page = type_result.follow()
+        self.assertContains(federal_page, TITLES["organization_federal"])
+        self.assertNotContains(federal_page, TITLES["organization_election"])
+
+    def test_application_form_conditional_elections(self):
+        """Election question is shown for other organizations."""
+        type_page = self.app.get(reverse("application")).follow()
+        # django-webtest does not handle cookie-based sessions well because it keeps
+        # resetting the session key on each new request, thus destroying the concept
+        # of a "session". We are going to do it manually, saving the session ID here
+        # and then setting the cookie on each request.
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+        # ---- TYPE PAGE  ----
+
+        # the conditional step titles shouldn't appear initially
+        self.assertNotContains(type_page, TITLES["organization_federal"])
+        self.assertNotContains(type_page, TITLES["organization_election"])
+        type_form = type_page.form
+        type_form["organization_type-organization_type"] = "County"
+
+        # set the session ID before .submit()
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        type_result = type_form.submit()
+
+        # the post request should return a redirect to the federal branch
+        # question
+        self.assertEquals(type_result.status_code, 302)
+        self.assertEquals(type_result["Location"], "/register/organization_election/")
+
+        # and the step label should appear in the sidebar of the resulting page
+        # but the step label for the elections page should not appear
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        election_page = type_result.follow()
+        self.assertContains(election_page, TITLES["organization_election"])
+        self.assertNotContains(election_page, TITLES["organization_federal"])

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -134,7 +134,6 @@ class FormTests(TestWithUser, WebTest):
         self.assertEquals(type_result.status_code, 302)
         self.assertEquals(type_result["Location"], "/register/organization_federal/")
 
-
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
@@ -147,9 +146,7 @@ class FormTests(TestWithUser, WebTest):
         federal_result = federal_form.submit()
 
         self.assertEquals(federal_result.status_code, 302)
-        self.assertEquals(
-            federal_result["Location"], "/register/organization_contact/"
-        )
+        self.assertEquals(federal_result["Location"], "/register/organization_contact/")
 
         # ---- ORG CONTACT PAGE  ----
         # Follow the redirect to the next form page


### PR DESCRIPTION
# Conditionally show forms based on organization type #

## 🗣 Description ##

For organizations that give their organization type as "Federal", we show an additional question about which Federal branch they belong to. For organizations that are other municipalities, we show an additional question about whether or not they are an election organization. The form wizard that we use allows conditionally showing steps based on answers to previous questions and the conditionally shown forms appear in the sidebar throughout the remainder of the process (see screenshot) which seems correct since it allows users to jump back and change their answer to that question.

![Screen Shot 2022-11-23 at 13 39 29](https://user-images.githubusercontent.com/443389/203633012-eb93e990-c9a3-4b67-9967-f3d9f8a72ba4.png)

There is a modicum of surprise when going back to the Organization type question and changing the answer away from Federal. When submit is clicked, then the "Type of organization - Federal" step disappears from the sidebar. I think that this is also a reasonable behavior.

## 💭 Motivation and context ##

Closes #256.