### PR TITLE
Use email instead of username UUID

### DIFF
--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -145,7 +145,8 @@
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item">
             {% if user.is_authenticated %}
-            <a href="/whoami"><span>{{ user.email }}</span></a>
+            <a href="/whoami"><span>{{ user.email }}</span></a> | <a
+                href="/openid/logout"><span>Sign out</span></a>
             {% else %}
             <a href="/openid/login"><span>Sign in</span></a>
             {% endif %}

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -145,9 +145,9 @@
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item">
             {% if user.is_authenticated %}
-            User: <a href="/whoami">{{ user.get_username }}</a>
+            <a href="/whoami"><span>{{ user.email }}</span></a>
             {% else %}
-            <a href="/openid/login">Sign in</a>
+            <a href="/openid/login"><span>Sign in</span></a>
             {% endif %}
           </li>
         </ul>


### PR DESCRIPTION
# Use email instead of ugly UUID username #

## 🗣 Description ##

Our Login.gov integration puts the Login.gov UUID into the `username` of the Django user. That means that it shows up in the top-right corner of our navigation bar. Which is (IMO) ugly. 

A recent conversation emphasized the primacy of email address for identifying logged-in users, so this changes the page template to display the logged-in email address in the top-right.

![Screen Shot 2022-12-07 at 10 23 01](https://user-images.githubusercontent.com/443389/206234361-bf2437e7-5c36-45af-b3d2-7e325f6d25ab.png)

## 💭 Motivation and context ##

Just scratching an itch to have the page look more pleasing with less gobbledygook.