### PR TITLE
Add/remove external link icons

### DIFF
--- a/src/registrar/templates/includes/footer.html
+++ b/src/registrar/templates/includes/footer.html
@@ -58,7 +58,7 @@
         >
           <p class="usa-identifier__identity-domain">get.gov</p>
           <p class="usa-identifier__identity-disclaimer">
-            An official website of the <a href="https://www.cisa.gov" class="usa-link usa-link--external">Cybersecurity and Infrastructure Security Agency</a>
+            An official website of the <a href="https://www.cisa.gov" class="usa-link">Cybersecurity and Infrastructure Security Agency</a>
           </p>
         </section>
       </div>
@@ -89,7 +89,7 @@
             >
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.dhs.gov/accessibility" class="usa-identifier__required-link usa-link"
+            <a href="https://www.dhs.gov/accessibility" class="usa-identifier__required-link usa-link usa-link--external"
               >Accessibility</a
             >
           </li>
@@ -104,7 +104,7 @@
             >
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.dhs.gov/freedom-information-act-foia" class="usa-identifier__required-link usa-link"
+            <a href="https://www.dhs.gov/freedom-information-act-foia" class="usa-identifier__required-link usa-link usa-link--external"
               >FOIA requests</a
             >
           </li>
@@ -119,6 +119,6 @@
         <div class="usa-identifier__usagov-description">
           Looking for U.S. government information and services?
         </div>
-        <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+        <a href="https://www.usa.gov/" class="usa-link usa-link--external">Visit USA.gov</a>
       </div>
     </section>


### PR DESCRIPTION
Added external link icons to links external to CISA

# Update external link icons in footer #

## 🗣 Description ##

Builds on #296 

## 💭 Motivation and context ##

Our policy will be to add the external link icon to sites that are external to CISA.