### PR TITLE
Permit skipping among visited pages on the form

### DIFF
--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -12,7 +12,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import resolve
 
 from formtools.wizard.views import NamedUrlSessionWizardView  # type: ignore
-from formtools.wizard.storage.session import SessionStorage
+from formtools.wizard.storage.session import SessionStorage  # type: ignore
 
 from registrar.models import Contact, DomainApplication, Domain
 

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -12,6 +12,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import resolve
 
 from formtools.wizard.views import NamedUrlSessionWizardView  # type: ignore
+from formtools.wizard.storage.session import SessionStorage
 
 from registrar.models import Contact, DomainApplication, Domain
 
@@ -382,6 +383,19 @@ WIZARD_CONDITIONS = {
 }
 
 
+class TrackingStorage(SessionStorage):
+
+    """Storage subclass that keeps track of what the current_step has been."""
+
+    def _set_current_step(self, step):
+        super()._set_current_step(step)
+
+        step_history = self.extra_data.setdefault("step_history", [])
+        # can't serialize a set, so keep list entries unique
+        if step not in step_history:
+            step_history.append(step)
+
+
 class ApplicationWizard(LoginRequiredMixin, NamedUrlSessionWizardView):
 
     """Multi-page form ("wizard") for new domain applications.
@@ -397,6 +411,7 @@ class ApplicationWizard(LoginRequiredMixin, NamedUrlSessionWizardView):
     """
 
     form_list = FORMS
+    storage_name = "registrar.forms.application_wizard.TrackingStorage"
 
     def get_template_names(self):
         """Template for the current step.
@@ -418,6 +433,14 @@ class ApplicationWizard(LoginRequiredMixin, NamedUrlSessionWizardView):
         """Add title information to the context for all steps."""
         context = super().get_context_data(form=form, **kwargs)
         context["form_titles"] = TITLES
+
+        # Add information about which steps should be unlocked
+        # TODO: sometimes the first step doesn't get added to the step history
+        # so add it here
+        context["visited"] = self.storage.extra_data.get("step_history", []) + [
+            self.steps.first
+        ]
+
         if self.steps.current == Step.ORGANIZATION_CONTACT:
             context["is_federal"] = self._is_federal()
         if self.steps.current == Step.REVIEW:

--- a/src/registrar/templates/application_sidebar.html
+++ b/src/registrar/templates/application_sidebar.html
@@ -3,7 +3,7 @@
   <nav aria-label="Form steps,">
     <ul class="usa-sidenav">
     {% for this_step in wizard.steps.all %}
-    {% if forloop.counter <= wizard.steps.step1 %}
+      {% if this_step in visited %}
       <li class="usa-sidenav__item">
         <a href="{% url wizard.url_name step=this_step %}" 
            {% if this_step == wizard.steps.current %}class="usa-current"{% endif%}>

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django_webtest import WebTest  # type: ignore
 
 from registrar.models import DomainApplication, Domain, Contact, Website
-from registrar.forms.application_wizard import TITLES
+from registrar.forms.application_wizard import TITLES, Step
 
 from .common import less_console_noise
 
@@ -616,6 +616,34 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = election_result.follow()
         self.assertNotContains(contact_page, "Federal agency")
+
+    def test_application_form_section_skipping(self):
+        """Can skip forward and back in sections"""
+        type_page = self.app.get(reverse("application")).follow()
+        # django-webtest does not handle cookie-based sessions well because it keeps
+        # resetting the session key on each new request, thus destroying the concept
+        # of a "session". We are going to do it manually, saving the session ID here
+        # and then setting the cookie on each request.
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+        type_form = type_page.form
+        type_form["organization_type-organization_type"] = "federal"
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        type_result = type_page.form.submit()
+
+        # follow first redirect
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        federal_page = type_result.follow()
+
+        # Now on federal type page, click back to the organization type
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        new_page = federal_page.click(TITLES[Step.ORGANIZATION_TYPE], index=0)
+
+        # Should be a link to the organization_federal page
+        self.assertGreater(
+            len(new_page.html.find_all("a", href="/register/organization_federal/")),
+            0,
+        )
 
     @skip("WIP")
     def test_application_edit_restore(self):


### PR DESCRIPTION
# Allow skipping between visited pages on the application form #

## 🗣 Description ##

If applicants go back to a previous section on the form using links in the sidebar, they should be able to use the sidebar to return to the furthest page that they had visited. This makes that possible by keeping track of the form steps that have been visited and allowing linking to any of the steps that have been visited before (they don't need to have been completed).

![Screen Shot 2022-12-16 at 11 08 21](https://user-images.githubusercontent.com/443389/208183804-c6c6df22-fbca-49e7-b305-432f8fcb5d50.png)

We do this by hooking into the structure of the form wizard so that each time the current step is set, we make a record of that fact in the wizard's session storage. Then we can consult that list in our template to determine whether or not to mark a step as locked or not.

## 💭 Motivation and context ##

Closes #285.