### PR TITLE
Change next and save button text

### DIFF
--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -49,7 +49,7 @@
             name="submit_button"
             value="next"
             class="usa-button"
-          >Next</button>
+          >Save and continue</button>
           {% else %}
           <button
             type="submit"
@@ -61,7 +61,7 @@
             name="submit_button"
             value="save"
             class="usa-button usa-button--outline"
-          >Save</button>
+          >Save progress</button>
         </div>
 
       </main>


### PR DESCRIPTION
## 🗣 Description ##
This PR change the "Next" button text in the form to "Save and continue", and "Save" to "Save progress"

## 💭 Motivation and context ##
This changes comes from a discussion in our design huddle a few weeks ago. Our hunch is that the updated text will be clearer, and we'd like to test the new language proposed in this PR with users to see if they understand that their application is saved as they progress and that they have the option to pause and pick up the application again. 
