### PR TITLE
Dynamic helper text for Authorizing Official

### DIFF
--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -19,6 +19,8 @@ i.e.
 @include u-padding-right('05');
 ----------------------------------------
 */
+// USWDS tokens are a bit too coarse in their letter-spacing steps
+$letter-space--xs: .0125em; 
 
 @use "uswds-core" as *;
 
@@ -41,6 +43,13 @@ i.e.
     margin-top: units(2);
   }
  }
+ 
+.register-form-step h3 {
+  color: color('primary-dark');
+  letter-spacing: $letter-space--xs;
+  margin-top: units(3);
+  margin-bottom: 0;
+}
 
 .register-form-step p {
   @include typeset('sans', 'sm', 5);
@@ -90,6 +99,10 @@ a.breadcrumb__back {
 
 .stepnav {
   margin-top: units(2);
+}
+
+.ao_example p {
+  margin-top: units(1);
 }
 
 .review__step__name {

--- a/src/registrar/templates/application_authorizing_official.html
+++ b/src/registrar/templates/application_authorizing_official.html
@@ -13,7 +13,29 @@
   </p>
 
   <div class="ao_example">
-    {% include "includes/ao_example__school-district.html" %}
+    {% if application.organization_type == 'federal' %}
+      {% if application.federal_type == 'executive' %}
+        {% include "includes/ao_example__exec.html" %}
+      {% elif application.federal_type == 'judicial' %}
+        {% include "includes/ao_example__judicial.html" %}
+      {% elif application.federal_type == 'legislative' %}
+        {% include "includes/ao_example__legislative.html" %}
+      {% endif %}
+    {% elif application.organization_type == 'city' %}
+        {% include "includes/ao_example__city.html" %}
+    {% elif application.organization_type == 'county' %}
+        {% include "includes/ao_example__county.html" %}
+    {% elif application.organization_type == 'interstate' %}
+        {% include "includes/ao_example__interstate.html" %}
+    {% elif application.organization_type == 'school_district' %}
+        {% include "includes/ao_example__school-district.html" %}
+    {% elif application.organization_type == 'special_district' %}
+        {% include "includes/ao_example__special-district.html" %}
+    {% elif application.organization_type == 'state_or_territory' %}
+        {% include "includes/ao_example__state-territory.html" %}
+    {% elif application.organization_type == 'tribal' %}
+      {% include "includes/ao_example__tribal.html" %}
+    {% endif %}
   </div>
 
   <p>We’ll contact your authorizing official to let them know that you made this request and to double check that they approve it.</p> 

--- a/src/registrar/templates/application_authorizing_official.html
+++ b/src/registrar/templates/application_authorizing_official.html
@@ -12,8 +12,8 @@
   <p>Your authorizing official is the person within your organization who can authorize your domain request. This is generally the highest ranking or highest elected official in your organization. Read more about <a href="{% url 'todo' %}">who can serve as an authorizing official</a>.
   </p>
 
-  <div class="ao-example">
-    {% include "includes/ao_example__city.html" %}
+  <div class="ao_example">
+    {% include "includes/ao_example__school-district.html" %}
   </div>
 
   <p>We’ll contact your authorizing official to let them know that you made this request and to double check that they approve it.</p> 

--- a/src/registrar/templates/application_authorizing_official.html
+++ b/src/registrar/templates/application_authorizing_official.html
@@ -13,27 +13,27 @@
   </p>
 
   <div class="ao_example">
-    {% if application.organization_type == 'federal' %}
-      {% if application.federal_type == 'executive' %}
+    {% if is_federal %}
+      {% if federal_type == 'executive' %}
         {% include "includes/ao_example__exec.html" %}
-      {% elif application.federal_type == 'judicial' %}
+      {% elif federal_type == 'judicial' %}
         {% include "includes/ao_example__judicial.html" %}
-      {% elif application.federal_type == 'legislative' %}
+      {% elif federal_type == 'legislative' %}
         {% include "includes/ao_example__legislative.html" %}
       {% endif %}
-    {% elif application.organization_type == 'city' %}
+    {% elif organization_type == 'city' %}
         {% include "includes/ao_example__city.html" %}
-    {% elif application.organization_type == 'county' %}
+    {% elif organization_type == 'county' %}
         {% include "includes/ao_example__county.html" %}
-    {% elif application.organization_type == 'interstate' %}
+    {% elif organization_type == 'interstate' %}
         {% include "includes/ao_example__interstate.html" %}
-    {% elif application.organization_type == 'school_district' %}
+    {% elif organization_type == 'school_district' %}
         {% include "includes/ao_example__school-district.html" %}
-    {% elif application.organization_type == 'special_district' %}
+    {% elif organization_type == 'special_district' %}
         {% include "includes/ao_example__special-district.html" %}
-    {% elif application.organization_type == 'state_or_territory' %}
+    {% elif organization_type == 'state_or_territory' %}
         {% include "includes/ao_example__state-territory.html" %}
-    {% elif application.organization_type == 'tribal' %}
+    {% elif organization_type == 'tribal' %}
       {% include "includes/ao_example__tribal.html" %}
     {% endif %}
   </div>

--- a/src/registrar/templates/includes/ao_example__city.html
+++ b/src/registrar/templates/includes/ao_example__city.html
@@ -1,1 +1,1 @@
-<p>Domain requests from <strong>cities</strong> must be authorized by the mayor or the equivalent highest elected official.</p>
+<p>Domain requests from cities must be authorized by <strong>the mayor</strong> or the equivalent <strong>highest elected official.</strong></p>

--- a/src/registrar/templates/includes/ao_example__county.html
+++ b/src/registrar/templates/includes/ao_example__county.html
@@ -1,0 +1,2 @@
+<p>Domain requests from counties must be authorized by the <strong>chair of the county commission </strong>or <strong>the equivalent highest elected official.</strong></p>
+

--- a/src/registrar/templates/includes/ao_example__exec.html
+++ b/src/registrar/templates/includes/ao_example__exec.html
@@ -1,3 +1,3 @@
-<p>Domain requests from executive branch agencies must be authorized by <strong>CIOs</strong> or <strong>agency heads</strong>.</p>
+<p>Domain requests from executive branch agencies must be authorized by <strong>Chief Information Officers</strong> or <strong>agency heads</strong>.</p>
 <p>Domain requests from executive branch agencies are subject to guidance issued by the U.S. Office of Management and Budget. </p>
 

--- a/src/registrar/templates/includes/ao_example__exec.html
+++ b/src/registrar/templates/includes/ao_example__exec.html
@@ -1,0 +1,3 @@
+<p>Domain requests from executive branch agencies must be authorized by <strong>CIOs</strong> or <strong>agency heads</strong>.</p>
+<p>Domain requests from executive branch agencies are subject to guidance issued by the U.S. Office of Management and Budget. </p>
+

--- a/src/registrar/templates/includes/ao_example__interstate.html
+++ b/src/registrar/templates/includes/ao_example__interstate.html
@@ -1,0 +1,2 @@
+<p>Domain requests from interstate organizations must be authorized by the <strong>highest-ranking executive</strong> (president, director, chair, or equivalent) or <strong>one of the state’s governors or CIOs.</strong></p>
+

--- a/src/registrar/templates/includes/ao_example__interstate.html
+++ b/src/registrar/templates/includes/ao_example__interstate.html
@@ -1,2 +1,2 @@
-<p>Domain requests from interstate organizations must be authorized by the <strong>highest-ranking executive</strong> (president, director, chair, or equivalent) or <strong>one of the state’s governors or CIOs.</strong></p>
+<p>Domain requests from interstate organizations must be authorized by the <strong>highest-ranking executive</strong> (president, director, chair, or equivalent) or <strong>one of the state’s governors or Chief Information Officers.</strong></p>
 

--- a/src/registrar/templates/includes/ao_example__judicial.html
+++ b/src/registrar/templates/includes/ao_example__judicial.html
@@ -1,0 +1,4 @@
+<p>Domain requests from the U.S. Supreme Court must be authorized by the <strong>director of information technology for the U.S. Supreme Court.</strong></p>
+<p>Domain requests from other judicial branch agencies must be authorized by the <strong>director</strong> or <strong>CIO of the Administrative Office (AO)</strong> of the United States Courts.
+</p>
+

--- a/src/registrar/templates/includes/ao_example__judicial.html
+++ b/src/registrar/templates/includes/ao_example__judicial.html
@@ -1,4 +1,4 @@
 <p>Domain requests from the U.S. Supreme Court must be authorized by the <strong>director of information technology for the U.S. Supreme Court.</strong></p>
-<p>Domain requests from other judicial branch agencies must be authorized by the <strong>director</strong> or <strong>CIO of the Administrative Office (AO)</strong> of the United States Courts.
+<p>Domain requests from other judicial branch agencies must be authorized by the <strong>director</strong> or <strong>Chief Information Officer of the Administrative Office (AO)</strong> of the United States Courts.
 </p>
 

--- a/src/registrar/templates/includes/ao_example__legislative.html
+++ b/src/registrar/templates/includes/ao_example__legislative.html
@@ -1,0 +1,10 @@
+<h3> U.S. Senate </h3>
+<p>Domain requests from the U.S. Senate must come from the <strong>Senate Sergeant at Arms.</strong></p>
+
+<h3> U.S. House of Representatives </h3>
+<p class="">Domain requests from the U.S. House of Representatives must come from the <strong>House Chief Administrative Officer.</strong>
+
+<h3> Other legislative branch agencies </h3>
+<p class="margin-top-1">Domain requests from legislative branch agencies must come from the <strong>agency’s head</strong> or <strong>CIO.</strong></p>
+<p class="margin-top-1">Domain requests from legislative commissions must come from the <strong>head of the commission</strong>, or the <strong>head or CIO of the parent agency,</strong> if there is one.
+</p>

--- a/src/registrar/templates/includes/ao_example__legislative.html
+++ b/src/registrar/templates/includes/ao_example__legislative.html
@@ -5,6 +5,6 @@
 <p class="">Domain requests from the U.S. House of Representatives must come from the <strong>House Chief Administrative Officer.</strong>
 
 <h3> Other legislative branch agencies </h3>
-<p class="margin-top-1">Domain requests from legislative branch agencies must come from the <strong>agency’s head</strong> or <strong>CIO.</strong></p>
-<p class="margin-top-1">Domain requests from legislative commissions must come from the <strong>head of the commission</strong>, or the <strong>head or CIO of the parent agency,</strong> if there is one.
+<p class="margin-top-1">Domain requests from legislative branch agencies must come from the <strong>agency’s head</strong> or <strong>Chief Information Officer.</strong></p>
+<p class="margin-top-1">Domain requests from legislative commissions must come from the <strong>head of the commission</strong>, or the <strong>head or Chief Information Officer of the parent agency,</strong> if there is one.
 </p>

--- a/src/registrar/templates/includes/ao_example__school-district.html
+++ b/src/registrar/templates/includes/ao_example__school-district.html
@@ -1,0 +1,3 @@
+<p>Domain requests from school district governments must be authorized by the <strong>highest-ranking executive (the chair of a school district’s board or a superintendent)</strong>.
+</p>
+

--- a/src/registrar/templates/includes/ao_example__special-district.html
+++ b/src/registrar/templates/includes/ao_example__special-district.html
@@ -1,0 +1,2 @@
+<p>Domain requests from special districts must be authorized by the <strong>highest-ranking executive (president, director, chair, or equivalent)</strong> or <strong>state CIOs for state-based organizations</strong>.</p>
+

--- a/src/registrar/templates/includes/ao_example__special-district.html
+++ b/src/registrar/templates/includes/ao_example__special-district.html
@@ -1,2 +1,2 @@
-<p>Domain requests from special districts must be authorized by the <strong>highest-ranking executive (president, director, chair, or equivalent)</strong> or <strong>state CIOs for state-based organizations</strong>.</p>
+<p>Domain requests from special districts must be authorized by the <strong>highest-ranking executive (president, director, chair, or equivalent)</strong> or <strong>state Chief Information Officers for state-based organizations</strong>.</p>
 

--- a/src/registrar/templates/includes/ao_example__state-territory.html
+++ b/src/registrar/templates/includes/ao_example__state-territory.html
@@ -1,5 +1,4 @@
 <h3>States and territories: executive branch</h3>
-<p>Domain requests from states and territories must be authorized by the <strong>governor</strong> or the <strong>state CIO.</strong></p>
+<p>Domain requests from states and territories must be authorized by the <strong>governor</strong> or the <strong>state Chief Information Officer.</strong></p>
 <h3>States and territories: judicial and legislative branches</h3>
-<p>Domain requests from state legislatures and courts must be authorized by an agency’s <strong>CIO</strong> or <strong>highest-ranking executive</strong>.</p>
-
+<p>Domain requests from state legislatures and courts must be authorized by an agency’s <strong>Chief Information Officer</strong> or <strong>highest-ranking executive</strong>.</p>

--- a/src/registrar/templates/includes/ao_example__state-territory.html
+++ b/src/registrar/templates/includes/ao_example__state-territory.html
@@ -1,0 +1,5 @@
+<h3>States and territories: executive branch</h3>
+<p>Domain requests from states and territories must be authorized by the <strong>governor</strong> or the <strong>state CIO.</strong></p>
+<h3>States and territories: judicial and legislative branches</h3>
+<p>Domain requests from state legislatures and courts must be authorized by an agency’s <strong>CIO</strong> or <strong>highest-ranking executive</strong>.</p>
+

--- a/src/registrar/templates/includes/ao_example__tribal.html
+++ b/src/registrar/templates/includes/ao_example__tribal.html
@@ -1,0 +1,2 @@
+<p>Domain requests from federally-recognized tribal governments must be authorized by <strong>tribal chiefs</strong> as noted by the <a href="https://www.bia.gov/service/tribal-leaders-directory" class="usa-link"> Bureau of Indian Affairs.</a></p>
+

--- a/src/registrar/templates/includes/required_fields.html
+++ b/src/registrar/templates/includes/required_fields.html
@@ -1,3 +1,3 @@
-  <p>
+  <p class="margin-top-3">
     Required fields are marked with an asterisk (<abbr class="usa-hint usa-hint--required" title="required">*</abbr>).
   </p>

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -802,7 +802,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Go back to AO page and test the dynamic text changed
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         ao_page = election_page.click(str(self.TITLES["authorizing_official"]), index=0)
-        self.assertContains(ao_page, "Domain requests from <strong>cities</strong>")
+        self.assertContains(ao_page, "Domain requests from cities")
 
     @skip("WIP")
     def test_application_edit_restore(self):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -739,7 +739,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         contact_page = type_result.follow()
 
         self.assertContains(contact_page, self.TITLES[Step.TYPE_OF_WORK])
-    
+
     def test_application_ao_dynamic_text(self):
         type_page = self.app.get(reverse("application:")).follow()
         # django-webtest does not handle cookie-based sessions well because it keeps
@@ -788,9 +788,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- AO CONTACT PAGE  ----
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         ao_page = org_contact_result.follow()
-        ao_form = ao_page.form
         self.assertContains(ao_page, "Domain requests from executive branch agencies")
-        
+
         # Go back to organization type page and change type
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         first_page = ao_page.click(str(self.TITLES["organization_type"]), index=0)
@@ -805,7 +804,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         ao_page = election_page.click(str(self.TITLES["authorizing_official"]), index=0)
         self.assertContains(ao_page, "Domain requests from <strong>cities</strong>")
-
 
     @skip("WIP")
     def test_application_edit_restore(self):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -739,6 +739,73 @@ class DomainApplicationTests(TestWithUser, WebTest):
         contact_page = type_result.follow()
 
         self.assertContains(contact_page, self.TITLES[Step.TYPE_OF_WORK])
+    
+    def test_application_ao_dynamic_text(self):
+        type_page = self.app.get(reverse("application:")).follow()
+        # django-webtest does not handle cookie-based sessions well because it keeps
+        # resetting the session key on each new request, thus destroying the concept
+        # of a "session". We are going to do it manually, saving the session ID here
+        # and then setting the cookie on each request.
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+        # ---- TYPE PAGE  ----
+        type_form = type_page.form
+        type_form["organization_type-organization_type"] = "federal"
+
+        # test next button
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        type_result = type_page.form.submit()
+
+        # ---- FEDERAL BRANCH PAGE  ----
+        # Follow the redirect to the next form page
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        federal_page = type_result.follow()
+        federal_form = federal_page.form
+        federal_form["organization_federal-federal_type"] = "executive"
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        federal_result = federal_form.submit()
+
+        # ---- ORG CONTACT PAGE  ----
+        # Follow the redirect to the next form page
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        org_contact_page = federal_result.follow()
+        org_contact_form = org_contact_page.form
+        # federal agency so we have to fill in federal_agency
+        org_contact_form[
+            "organization_contact-federal_agency"
+        ] = "General Services Administration"
+        org_contact_form["organization_contact-organization_name"] = "Testorg"
+        org_contact_form["organization_contact-address_line1"] = "address 1"
+        org_contact_form["organization_contact-address_line2"] = "address 2"
+        org_contact_form["organization_contact-city"] = "NYC"
+        org_contact_form["organization_contact-state_territory"] = "NY"
+        org_contact_form["organization_contact-zipcode"] = "10002"
+        org_contact_form["organization_contact-urbanization"] = "URB Royal Oaks"
+
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        org_contact_result = org_contact_form.submit()
+
+        # ---- AO CONTACT PAGE  ----
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        ao_page = org_contact_result.follow()
+        ao_form = ao_page.form
+        self.assertContains(ao_page, "Domain requests from executive branch agencies")
+        
+        # Go back to organization type page and change type
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        first_page = ao_page.click(str(self.TITLES["organization_type"]), index=0)
+        type_form = type_page.form
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        type_form["organization_type-organization_type"] = "city"
+        type_result = type_form.submit()
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        election_page = type_result.follow()
+
+        # Go back to AO page and test the dynamic text changed
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        ao_page = election_page.click(str(self.TITLES["authorizing_official"]), index=0)
+        self.assertContains(ao_page, "Domain requests from <strong>cities</strong>")
+
 
     @skip("WIP")
     def test_application_edit_restore(self):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -792,8 +792,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # Go back to organization type page and change type
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        first_page = ao_page.click(str(self.TITLES["organization_type"]), index=0)
-        type_form = type_page.form
+        ao_page.click(str(self.TITLES["organization_type"]), index=0)
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         type_form["organization_type-organization_type"] = "city"
         type_result = type_form.submit()

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -367,8 +367,9 @@ class AuthorizingOfficial(ApplicationWizard):
 
     def get_context_data(self):
         context = super().get_context_data()
-        context["Step"] = Step.__members__
-        context["application"] = self.application
+        context["is_federal"] = self.application.is_federal()
+        context["organization_type"] = self.application.organization_type
+        context["federal_type"] = self.application.federal_type
         return context
 
 

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -365,6 +365,12 @@ class AuthorizingOfficial(ApplicationWizard):
     template_name = "application_authorizing_official.html"
     forms = [forms.AuthorizingOfficialForm]
 
+    def get_context_data(self):
+        context = super().get_context_data()
+        context["Step"] = Step.__members__
+        context["application"] = self.application
+        return context
+
 
 class CurrentSites(ApplicationWizard):
     template_name = "application_current_sites.html"


### PR DESCRIPTION
## 🗣 Description ##

This PR adds content for the authority official for each type of government organization, and and implements logic to display the relevant text based on the registrant's organization type. 

## 💭 Motivation and context ##
Part of #330 . If this approach and implementation looks good, I will extend it to the .gov page as well. 