### PR TITLE
Add confirmation and caution message to the forms

### DIFF
--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -18,6 +18,10 @@
         </a>
         {% endif %}
 
+{% block form_messages %}
+          {% include "includes/form_messages.html" %}
+{% endblock %}
+
 {% block form_errors %}
         {% comment %}
            to make sense of this loop, consider that 

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -167,9 +167,11 @@
     {% if messages %}
     <ul class="messages">
       {% for message in messages %}
+      {% if 'base' in message.extra_tags %}
       <li{% if message.tags %} class="{{ message.tags }}" {% endif %}>
         {{ message }}
         </li>
+        {% endif %}
         {% endfor %}
     </ul>
     {% endif %}

--- a/src/registrar/templates/includes/form_errors.html
+++ b/src/registrar/templates/includes/form_errors.html
@@ -1,5 +1,9 @@
+{% comment %}
+Commenting the code below to turn off the error because 
+we are showing the caution dialog instead. But saving in 
+case we want to revert this. 
 {% if form.errors %}
-  {% for error in form.non_field_errors %}
+{% for error in form.non_field_errors %}
     <div class="usa-alert usa-alert--error usa-alert--slim margin-bottom-2">
     <div class="usa-alert__body">
     {{ error|escape }}
@@ -16,3 +20,4 @@
     {% endfor %}
   {% endfor %}
 {% endif %}
+{% endcomment %}

--- a/src/registrar/templates/includes/form_messages.html
+++ b/src/registrar/templates/includes/form_messages.html
@@ -1,0 +1,10 @@
+{% if messages %}
+{% for message in messages %}
+<div class="usa-alert usa-alert--{{ message.tags }} usa-alert--slim margin-bottom-2">
+    <div class="usa-alert__body">
+       {{ message }}
+    </div>
+</div>
+
+{% endfor %}
+{% endif %}

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -331,6 +331,8 @@ class ApplicationWizard(LoginRequiredMixin, TemplateView):
                     + "fields below <b>could not be saved</b> because they have "
                     + "missing or invalid data. All other information on this page "
                     + "has been saved."
+                ),
+            )
             context = self.get_context_data()
             context["forms"] = forms
             return render(request, self.template_name, context)

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -6,6 +6,8 @@ from django.shortcuts import redirect, render
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
+from django.contrib import messages
+from django.utils.safestring import mark_safe
 
 from registrar.forms import application_wizard as forms
 from registrar.models import DomainApplication
@@ -319,6 +321,16 @@ class ApplicationWizard(LoginRequiredMixin, TemplateView):
             self.save(forms)
         else:
             # unless there are errors
+            # no sec because this use of mark_safe does not introduce a cross-site
+            # scripting vulnerability because there is no untrusted content inside.
+            # It is only being used to pass a specific HTML entity into a template.
+            messages.warning(
+                request,
+                mark_safe(  # nosec
+                    "<b>We could not save all the fields.</b><br/> The highlighted "
+                    + "fields below <b>could not be saved</b> because they have "
+                    + "missing or invalid data. All other information on this page "
+                    + "has been saved."
             context = self.get_context_data()
             context["forms"] = forms
             return render(request, self.template_name, context)
@@ -326,6 +338,7 @@ class ApplicationWizard(LoginRequiredMixin, TemplateView):
         # if user opted to save their progress,
         # return them to the page they were already on
         if button == "save":
+            messages.success(request, "Your progress has been saved!")
             return self.goto(self.steps.current)
         # otherwise, proceed as normal
         return self.goto_next_step()


### PR DESCRIPTION
This is same PR of #414, just with cleaner branch with all changes "signed" (Github wasnt playing nice with me with the older branch because it had my personal email which caused github to "unsigned" the first two changes which was then corrected in the commits after these two. However I could not rebase the first two commit in that PR, and I fear making any further changes/modify to the branch will make problem than benefit.

## 🗣 Description ##

Complete #398 
Based on PR #414 

- Added messages to forms
- Added confirmation message when saved progress
- Changed the error message in form to caution
- Commented out the error message on the top of form
- Changed the message in base to only show if it have extra_tag base

## 💭 Motivation and context ##

Closes ticket https://github.com/cisagov/getgov/issues/398. Also did caution message which is already shown according to UX design (we already have ticket (359) for caution but that ticket focus on be able to save partial fields instead of the UI)