### PR TITLE
Place the contact rationale box on its own page

### DIFF
--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -35,6 +35,7 @@ for step, view in [
     (Step.PURPOSE, views.Purpose),
     (Step.YOUR_CONTACT, views.YourContact),
     (Step.OTHER_CONTACTS, views.OtherContacts),
+    (Step.NO_OTHER_CONTACTS, views.NoOtherContacts),
     (Step.SECURITY_EMAIL, views.SecurityEmail),
     (Step.ANYTHING_ELSE, views.AnythingElse),
     (Step.REQUIREMENTS, views.Requirements),

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -662,7 +662,7 @@ OtherContactsFormSet = forms.formset_factory(
 
 class NoOtherContactsForm(RegistrarForm):
     no_other_contacts_rationale = forms.CharField(
-        required=False,
+        required=True,
         # label has to end in a space to get the label_suffix to show
         label=(
             "If you can’t provide other contacts for your organization,"

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -545,6 +545,10 @@ class DomainApplication(TimeStampedModel):
             DomainApplication.OrganizationChoices.INTERSTATE,
         ]
 
+    def show_no_other_contacts_rationale(self) -> bool:
+        """Show this step if the other contacts are blank."""
+        return not self.other_contacts.exists()
+
     def is_federal(self) -> Union[bool, None]:
         """Is this application for a federal agency?
 

--- a/src/registrar/templates/application_no_other_contacts.html
+++ b/src/registrar/templates/application_no_other_contacts.html
@@ -1,0 +1,6 @@
+{% extends 'application_form.html' %}
+{% load static field_helpers %}
+
+{% block form_fields %}
+  {% input_with_errors forms.0.no_other_contacts_rationale %}
+{% endblock %}

--- a/src/registrar/templates/application_other_contacts.html
+++ b/src/registrar/templates/application_other_contacts.html
@@ -39,8 +39,4 @@
       <use xlink:href="{%static 'img/sprite.svg'%}#add_circle"></use>
     </svg><span class="margin-left-05">Add another contact</span>
   </button>
-
-  <h2>No contacts</h2>
-
-  {% input_with_errors forms.1.no_other_contacts_rationale %}
 {% endblock %}

--- a/src/registrar/templates/application_review.html
+++ b/src/registrar/templates/application_review.html
@@ -36,7 +36,9 @@
           {% endif %}
           {% if step == Step.AUTHORIZING_OFFICIAL %}
             {% if application.authorizing_official %}
-              {% include "includes/contact.html" with contact=application.authorizing_official %}
+              <div class="margin-bottom-105">
+                {% include "includes/contact.html" with contact=application.authorizing_official %}
+              </div>
             {% else %}
               Incomplete
             {% endif %}
@@ -51,8 +53,10 @@
             </ul>
           {% endif %}
           {% if step == Step.DOTGOV_DOMAIN %}
-            <ul class="add-list-reset">
+            <ul class="add-list-reset margin-bottom-105">
               <li>{{ application.requested_domain.name|default:"Incomplete" }}</li>
+            </ul>
+            <ul class="add-list-reset">
               {% for site in application.alternative_domains.all %}
                 <li>{{ site.website }}</li>
               {% endfor %}
@@ -63,17 +67,24 @@
           {% endif %}
           {% if step == Step.YOUR_CONTACT %}
               {% if application.submitter %}
-                {% include "includes/contact.html" with contact=application.submitter %}
+                <div class="margin-bottom-105">
+                  {% include "includes/contact.html" with contact=application.submitter %}
+                </div>
               {% else %}
                 Incomplete
               {% endif %}
           {% endif %}
           {% if step == Step.OTHER_CONTACTS %}
             {% for other in application.other_contacts.all %}
+              <div class="margin-bottom-105">
                 {% include "includes/contact.html" with contact=other %}
+              </div>
             {% empty %}
               None
             {% endfor %}
+          {% endif %}
+          {% if step == Step.NO_OTHER_CONTACTS %}
+            {{ application.no_other_contacts_rationale|default:"Incomplete" }}
           {% endif %}
           {% if step == Step.SECURITY_EMAIL %}
             {{ application.security_email|default:"None" }}
@@ -82,7 +93,7 @@
             {{ application.anything_else|default:"No" }}
           {% endif %}
           {% if step == Step.REQUIREMENTS %}
-            {{ application.is_policy_acknowledged|yesno:"Agree,Do not agree,Do not agree" }}
+            {{ application.is_policy_acknowledged|yesno:"I agree.,I do not agree.,I do not agree." }}
           {% endif %}
         </div>
       </div>

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -124,7 +124,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         this test work.
         """
         num_pages_tested = 0
-        SKIPPED_PAGES = 3  # elections, type_of_work, tribal_government
+        # elections, type_of_work, tribal_government, no_other_contacts
+        SKIPPED_PAGES = 4
         num_pages = len(self.TITLES) - SKIPPED_PAGES
 
         type_page = self.app.get(reverse("application:")).follow()
@@ -723,6 +724,24 @@ class DomainApplicationTests(TestWithUser, WebTest):
         contact_page = type_result.follow()
 
         self.assertContains(contact_page, self.TITLES[Step.TYPE_OF_WORK])
+
+    def test_application_no_other_contacts(self):
+        """Applicants with no other contacts have to give a reason."""
+        contacts_page = self.app.get(reverse("application:other_contacts"))
+        # django-webtest does not handle cookie-based sessions well because it keeps
+        # resetting the session key on each new request, thus destroying the concept
+        # of a "session". We are going to do it manually, saving the session ID here
+        # and then setting the cookie on each request.
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        result = contacts_page.form.submit()
+        # follow first redirect
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        no_contacts_page = result.follow()
+        expected_url_slug = str(Step.NO_OTHER_CONTACTS)
+        actual_url_slug = no_contacts_page.request.path.split("/")[-2]
+        self.assertEqual(expected_url_slug, actual_url_slug)
 
     def test_application_type_of_work_interstate(self):
         """Special districts have to answer an additional question."""

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -35,6 +35,7 @@ class Step(StrEnum):
     PURPOSE = "purpose"
     YOUR_CONTACT = "your_contact"
     OTHER_CONTACTS = "other_contacts"
+    NO_OTHER_CONTACTS = "no_other_contacts"
     SECURITY_EMAIL = "security_email"
     ANYTHING_ELSE = "anything_else"
     REQUIREMENTS = "requirements"
@@ -80,6 +81,7 @@ class ApplicationWizard(LoginRequiredMixin, TemplateView):
         Step.PURPOSE: _("Purpose of your domain"),
         Step.YOUR_CONTACT: _("Your contact information"),
         Step.OTHER_CONTACTS: _("Other contacts for your organization"),
+        Step.NO_OTHER_CONTACTS: _("No other contacts?"),
         Step.SECURITY_EMAIL: _("Security email for public use"),
         Step.ANYTHING_ELSE: _("Anything else we should know?"),
         Step.REQUIREMENTS: _(
@@ -99,6 +101,9 @@ class ApplicationWizard(LoginRequiredMixin, TemplateView):
             "show_organization_election", False
         ),
         Step.TYPE_OF_WORK: lambda w: w.from_model("show_type_of_work", False),
+        Step.NO_OTHER_CONTACTS: lambda w: w.from_model(
+            "show_no_other_contacts_rationale", False
+        ),
     }
 
     def __init__(self):
@@ -410,7 +415,12 @@ class YourContact(ApplicationWizard):
 
 class OtherContacts(ApplicationWizard):
     template_name = "application_other_contacts.html"
-    forms = [forms.OtherContactsFormSet, forms.NoOtherContactsForm]
+    forms = [forms.OtherContactsFormSet]
+
+
+class NoOtherContacts(ApplicationWizard):
+    template_name = "application_no_other_contacts.html"
+    forms = [forms.NoOtherContactsForm]
 
 
 class SecurityEmail(ApplicationWizard):


### PR DESCRIPTION
## 🗣 Description ##

This places the "no other contacts" justification box on a second page. If applicants provide other contacts, that page is removed from the navigational menu. If they do not, they are taken to that page and required to fill in the box.

This PR also puts that info on the review page.

## 💭 Motivation and context ##

Closes #424 