### PR TITLE
Simple user management

### DIFF
--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -222,7 +222,9 @@ section.dashboard {
   p {
     margin-bottom: 0;
   }
+}
 
+.dotgov-table {
   .usa-table {
     width: 100%;
 

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -63,6 +63,11 @@ urlpatterns = [
     ),
     path("domain/<int:pk>", views.DomainView.as_view(), name="domain"),
     path("domain/<int:pk>/users", views.DomainUsersView.as_view(), name="domain-users"),
+    path(
+        "domain/<int:pk>/users/add",
+        views.DomainAddUserView.as_view(),
+        name="domain-users-add",
+    ),
 ]
 
 

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
         name="todo",
     ),
     path("domain/<int:pk>", views.DomainView.as_view(), name="domain"),
+    path("domain/<int:pk>/users", views.DomainUsersView.as_view(), name="domain-users"),
 ]
 
 

--- a/src/registrar/fixtures.py
+++ b/src/registrar/fixtures.py
@@ -107,6 +107,10 @@ class DomainApplicationFixture:
             "status": "investigating",
             "organization_name": "Example - In Investigation",
         },
+        {
+            "status": "investigating",
+            "organization_name": "Example - Approved",
+        },
     ]
 
     @classmethod
@@ -249,3 +253,22 @@ class DomainApplicationFixture:
                     cls._set_many_to_many_relations(da, app)
                 except Exception as e:
                     logger.warning(e)
+
+class DomainFixture(DomainApplicationFixture):
+
+    """Create one domain and permissions on it for each user."""
+
+    @classmethod
+    def load(cls):
+        try:
+            users = list(User.objects.all())  # force evaluation to catch db errors
+        except Exception as e:
+            logger.warning(e)
+            return
+
+        for user in users:
+            # approve one of each users investigating status domains
+            application = DomainApplication.objects.filter(creator=user, status=DomainApplication.INVESTIGATING).last()
+            logger.debug(f"Approving {application} for {user}")
+            application.approve()
+            application.save()

--- a/src/registrar/fixtures.py
+++ b/src/registrar/fixtures.py
@@ -254,6 +254,7 @@ class DomainApplicationFixture:
                 except Exception as e:
                     logger.warning(e)
 
+
 class DomainFixture(DomainApplicationFixture):
 
     """Create one domain and permissions on it for each user."""
@@ -268,7 +269,9 @@ class DomainFixture(DomainApplicationFixture):
 
         for user in users:
             # approve one of each users investigating status domains
-            application = DomainApplication.objects.filter(creator=user, status=DomainApplication.INVESTIGATING).last()
+            application = DomainApplication.objects.filter(
+                creator=user, status=DomainApplication.INVESTIGATING
+            ).last()
             logger.debug(f"Approving {application} for {user}")
             application.approve()
             application.save()

--- a/src/registrar/forms/__init__.py
+++ b/src/registrar/forms/__init__.py
@@ -1,1 +1,2 @@
 from .application_wizard import *
+from .domain import DomainAddUserForm

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -1,0 +1,21 @@
+"""Forms for domain management."""
+
+from django import forms
+
+from registrar.models import User
+
+
+class DomainAddUserForm(forms.Form):
+
+    """Form for adding a user to a domain."""
+
+    email = forms.EmailField(label="Email")
+
+    def clean_email(self):
+        requested_email = self.cleaned_data["email"]
+        try:
+            User.objects.get(email=requested_email)
+        except User.DoesNotExist:
+            # TODO: send an invitation email to a non-existent user
+            raise forms.ValidationError("That user does not exist in this system.")
+        return requested_email

--- a/src/registrar/management/commands/load.py
+++ b/src/registrar/management/commands/load.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 from auditlog.context import disable_auditlog  # type: ignore
 
-from registrar.fixtures import UserFixture, DomainApplicationFixture
+from registrar.fixtures import UserFixture, DomainApplicationFixture, DomainFixture
 
 logger = logging.getLogger(__name__)
 
@@ -15,4 +15,5 @@ class Command(BaseCommand):
         with disable_auditlog():
             UserFixture.load()
             DomainApplicationFixture.load()
+            DomainFixture.load()
             logger.info("All fixtures loaded.")

--- a/src/registrar/templates/domain_add_user.html
+++ b/src/registrar/templates/domain_add_user.html
@@ -1,0 +1,24 @@
+{% extends "domain_base.html" %}
+{% load static field_helpers %}
+
+{% block title %}Add another user{% endblock %}
+
+{% block domain_content %}
+  <h1>Add another user</h1>
+
+  <p>You can add another user to help manage your domain. They will need to sign
+  into the .gov registrar with their Login.gov account.
+  </p>
+
+  <form class="usa-form usa-form--large" method="post" novalidate>
+    {% csrf_token %}
+
+    {% input_with_errors form.email %}
+
+    <button
+      type="submit"
+      class="usa-button"
+    >Add user</button>
+  </form>
+
+{% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_add_user.html
+++ b/src/registrar/templates/domain_add_user.html
@@ -4,6 +4,13 @@
 {% block title %}Add another user{% endblock %}
 
 {% block domain_content %}
+  <p><a href="{% url "domain-users" pk=domain.id %}">
+       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlink:href="{% static 'img/sprite.svg' %}#arrow_back"></use>
+      </svg>
+      Back to user management
+    </a>
+  </p>
   <h1>Add another user</h1>
 
   <p>You can add another user to help manage your domain. They will need to sign

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -12,12 +12,22 @@
     <div class="grid-col-9">
       <main id="main-content" class="grid-container">
 
-	  {% block domain_content %}
-	  <h1>Domain {{ domain.name }}</h1>
+      {% if messages %}
+      {% for message in messages %}
+      <div class="usa-alert usa-alert--{{ message.tags }} usa-alert--slim margin-bottom-2">
+          <div class="usa-alert__body">
+          {{ message }}
+          </div>
+      </div>
+      {% endfor %}
+      {% endif %}
 
-	  {% endblock %}  {# domain_content #}
+      {% block domain_content %}
+      <h1>Domain {{ domain.name }}</h1>
 
-	  </main>
+      {% endblock %}  {# domain_content #}
+
+      </main>
     </div>
   </div>
 </div>

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -1,0 +1,24 @@
+{% extends "dashboard_base.html" %}
+
+{% block title %}Domain {{ domain.name }}{% endblock %}
+
+{% block content %}
+<div class="grid-container">
+  <div class="grid-row grid-gap">
+    <div class="grid-col-3">
+      {% include 'domain_sidebar.html' %}
+    </div>
+
+    <div class="grid-col-9">
+      <main id="main-content" class="grid-container">
+
+	  <h1>Domain {{ domain.name }}</h1>
+
+	  {% block domain_content %}
+	  {% endblock %}  {# domain_content #}
+
+	  </main>
+    </div>
+  </div>
+</div>
+{% endblock %}  {# content #}

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -1,4 +1,4 @@
-{% extends "dashboard_base.html" %}
+{% extends "base.html" %}
 
 {% block title %}Domain {{ domain.name }}{% endblock %}
 
@@ -12,9 +12,9 @@
     <div class="grid-col-9">
       <main id="main-content" class="grid-container">
 
+	  {% block domain_content %}
 	  <h1>Domain {{ domain.name }}</h1>
 
-	  {% block domain_content %}
 	  {% endblock %}  {# domain_content #}
 
 	  </main>

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}Domain {{ domain.name }}{% endblock %}
 
@@ -23,6 +24,13 @@
       {% endif %}
 
       {% block domain_content %}
+	  <p><a href="{% url 'home' %}">
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlink:href="{% static 'img/sprite.svg' %}#arrow_back"></use>
+        </svg>
+        Back to manage your domains
+      </a></p>
+
       <h1>Domain {{ domain.name }}</h1>
 
       {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -1,21 +1,5 @@
-{% extends "dashboard_base.html" %}
+{% extends "domain_base.html" %}
 
-
-{% block title %}Domain {{ domain.name }}{% endblock %}
-
-{% block content %}
-<main id="main-content" class="grid-container">
-<div class="tablet:grid-offset-1 desktop:grid-offset-2">
-  <h1>{{ domain.name }}</h1>
-
-  <p>Active: {% if domain.is_active %}Yes{% else %}No{% endif %}</p>
-
-  <h2>Users</h2>
-  <ul>
-  {% for user in domain.users.all %}
-  <li>{{ user }} &lt;{{ user.email }}&gt;</li>
-  {% endfor %}
-  </ul>
-</div>
-</main>
-{% endblock %}  {# content #}
+{% block domain_content %}
+ <p>Active: {% if domain.is_active %}Yes{% else %}No{% endif %}</p>
+{% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -1,5 +1,6 @@
 {% extends "domain_base.html" %}
 
 {% block domain_content %}
- <p>Active: {% if domain.is_active %}Yes{% else %}No{% endif %}</p>
+  {{ block.super }}
+  <p>Active: {% if domain.is_active %}Yes{% else %}No{% endif %}</p>
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -9,6 +9,13 @@
   <h1>{{ domain.name }}</h1>
 
   <p>Active: {% if domain.is_active %}Yes{% else %}No{% endif %}</p>
+
+  <h2>Users</h2>
+  <ul>
+  {% for user in domain.users.all %}
+  <li>{{ user }} &lt;{{ user.email }}&gt;</li>
+  {% endfor %}
+  </ul>
 </div>
 </main>
 {% endblock %}  {# content #}

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -51,7 +51,7 @@
       <li class="usa-sidenav__item">
         {% url 'domain-users' pk=domain.id as url %}
         <a href="{{ url }}"
-          {% if request.path == url %}class="usa-current"{% endif %}
+          {% if request.path|startswith:url %}class="usa-current"{% endif %}
         >
             User management
         </a>

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -1,0 +1,61 @@
+{% load static url_helpers %}
+
+<div class="margin-bottom-4 tablet:margin-bottom-0">
+  <nav aria-label="Domain sections">
+    <ul class="usa-sidenav">
+      <li class="usa-sidenav__item">
+        {% url 'domain' pk=domain.id as url %} 
+        <a href="{{ url }}" 
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+          Domain Overview
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        {% url 'todo' as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+            DNS name servers
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        {% url 'todo' as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+            Authorizing official
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        {% url 'todo' as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+            Your contact information
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        {% url 'todo' as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+            Security email
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        {% url 'domain-users' pk=domain.id as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+            User management
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -4,6 +4,13 @@
 {% block title %}User management{% endblock %}
 
 {% block domain_content %}
+  <p><a href="{% url 'home' %}">
+    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+    <use xlink:href="{% static 'img/sprite.svg' %}#arrow_back"></use>
+    </svg>
+    Back to manage your domains
+  </a></p>
+
   <h1>User management</h1>
 
   {% if domain.permissions %}

--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -1,0 +1,10 @@
+{% extends "domain_base.html" %}
+
+{% block domain_content %}
+<h2>Users</h2>
+  <ul>
+  {% for user in domain.users.all %}
+	<li>{{ user }} &lt;{{ user.email }}&gt;</li>
+  {% endfor %}
+  </ul>
+{% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -1,4 +1,5 @@
 {% extends "domain_base.html" %}
+{% load static %}
 
 {% block title %}User management{% endblock %}
 
@@ -30,4 +31,11 @@
       aria-live="polite"
     ></div>
   {% endif %}
+
+  <a class="usa-button usa-button--unstyled" href="{% url 'domain-users-add' pk=domain.id %}">
+    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
+      <use xlink:href="{%static 'img/sprite.svg'%}#add_circle"></use>
+    </svg><span class="margin-left-05">Add another user</span>
+  </a>
+
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -1,10 +1,33 @@
 {% extends "domain_base.html" %}
 
+{% block title %}User management{% endblock %}
+
 {% block domain_content %}
-<h2>Users</h2>
-  <ul>
-  {% for user in domain.users.all %}
-	<li>{{ user }} &lt;{{ user.email }}&gt;</li>
-  {% endfor %}
-  </ul>
+  <h1>User management</h1>
+
+  {% if domain.permissions %}
+  <table class="dotgov-table usa-table usa-table--borderless usa-table--stacked">
+      <caption class="sr-only">Domain users</caption>
+      <thead>
+        <tr>
+          <th data-sortable scope="col" role="columnheader">Email</th>
+          <th data-sortable scope="col" role="columnheader">Role</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for permission in domain.permissions.all %}
+        <tr>
+          <th scope="row" role="rowheader" data-sort-value="{{ user.email }}" data-label="Domain name">
+            {{ permission.user.email }}
+          </th>
+          <td data-label="Role">{{ permission.role|title }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div
+      class="usa-sr-only usa-table__announcement-region"
+      aria-live="polite"
+    ></div>
+  {% endif %}
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -111,7 +111,7 @@
 
   <section class="tablet:grid-col-11 desktop:grid-col-10">
     <h2 class="padding-top-1 mobile-lg:padding-top-3"> Export domains</h2>
-    <p>If you would like to analyze your list of domains further, you can download the list of domains and their statuses as csv file</p>
+    <p>Download a list of your domains and their statuses as a csv file.</p>
     <a href="{% url 'todo' %}" class="usa-button usa-button--outline">
       Export domains as csv
     </a>

--- a/src/registrar/templatetags/url_helpers.py
+++ b/src/registrar/templatetags/url_helpers.py
@@ -8,3 +8,10 @@ register = template.Library()
 def namespaced_url(namespace, name="", **kwargs):
     """Get a URL, given its Django namespace and name."""
     return reverse(f"{namespace}:{name}", kwargs=kwargs)
+
+
+@register.filter("startswith")
+def startswith(text, starts):
+    if isinstance(text, str):
+        return text.startswith(starts)
+    return False

--- a/src/registrar/views/__init__.py
+++ b/src/registrar/views/__init__.py
@@ -1,5 +1,5 @@
 from .application import *
-from .domain import *
+from .domain import DomainView, DomainUsersView, DomainAddUserView
 from .health import *
 from .index import *
 from .whoami import *

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1,6 +1,7 @@
 """View for a single Domain."""
 
 from django import forms
+from django.contrib import messages
 from django.db import IntegrityError
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -71,4 +72,5 @@ class DomainAddUserView(DomainPermission, FormMixin, DetailView):
             # User already has the desired role! Do nothing??
             pass
 
+        messages.success(self.request, f"Added user {requested_email}.")
         return redirect(self.get_success_url())

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -14,12 +14,18 @@ from .utility import DomainPermission
 
 
 class DomainView(DomainPermission, DetailView):
+
+    """Domain detail overview page."""
+
     model = Domain
     template_name = "domain_detail.html"
     context_object_name = "domain"
 
 
 class DomainUsersView(DomainPermission, DetailView):
+
+    """User management page in the domain details."""
+
     model = Domain
     template_name = "domain_users.html"
     context_object_name = "domain"
@@ -42,6 +48,13 @@ class DomainAddUserForm(DomainPermission, forms.Form):
 
 
 class DomainAddUserView(DomainPermission, FormMixin, DetailView):
+
+    """Inside of a domain's user management, a form for adding users.
+
+    Multiple inheritance is used here for permissions, form handling, and
+    details of the individual domain.
+    """
+
     template_name = "domain_add_user.html"
     model = Domain
     form_class = DomainAddUserForm

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -11,3 +11,9 @@ class DomainView(DomainPermission, DetailView):
     model = Domain
     template_name = "domain_detail.html"
     context_object_name = "domain"
+
+
+class DomainUsersView(DomainPermission, DetailView):
+    model = Domain
+    template_name = "domain_users.html"
+    context_object_name = "domain"

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1,8 +1,13 @@
 """View for a single Domain."""
 
+from django import forms
+from django.db import IntegrityError
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic import DetailView
+from django.views.generic.edit import FormMixin
 
-from registrar.models import Domain
+from registrar.models import Domain, User, UserDomainRole
 
 from .utility import DomainPermission
 
@@ -17,3 +22,53 @@ class DomainUsersView(DomainPermission, DetailView):
     model = Domain
     template_name = "domain_users.html"
     context_object_name = "domain"
+
+
+class DomainAddUserForm(DomainPermission, forms.Form):
+
+    """Form for adding a user to a domain."""
+
+    email = forms.EmailField(label="Email")
+
+    def clean_email(self):
+        requested_email = self.cleaned_data["email"]
+        try:
+            User.objects.get(email=requested_email)
+        except User.DoesNotExist:
+            # TODO: send an invitation email to a non-existent user
+            raise forms.ValidationError("That user does not exist in this system.")
+        return requested_email
+
+
+class DomainAddUserView(DomainPermission, FormMixin, DetailView):
+    template_name = "domain_add_user.html"
+    model = Domain
+    form_class = DomainAddUserForm
+
+    def get_success_url(self):
+        return reverse("domain-users", kwargs={"pk": self.object.pk})
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        form = self.get_form()
+        if form.is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
+    def form_valid(self, form):
+        """Add the specified user on this domain."""
+        requested_email = form.cleaned_data["email"]
+        # look up a user with that email
+        # they should exist because we checked in clean_email
+        requested_user = User.objects.get(email=requested_email)
+
+        try:
+            UserDomainRole.objects.create(
+                user=requested_user, domain=self.object, role=UserDomainRole.Roles.ADMIN
+            )
+        except IntegrityError:
+            # User already has the desired role! Do nothing??
+            pass
+
+        return redirect(self.get_success_url())

--- a/src/zap.conf
+++ b/src/zap.conf
@@ -48,7 +48,7 @@
 10038	OUTOFSCOPE	http://app:8080/public/img/.*
 10038	OUTOFSCOPE	http://app:8080/public/css/.*
 10038	OUTOFSCOPE	http://app:8080/public/js/.*
-10038	OUTOFSCOPE	http://app:8080/(robots.txt|sitemap.xml|TODO|edit/)
+10038	OUTOFSCOPE	http://app:8080/(robots.txt|sitemap.xml|TODO|edit|users/)
 # This URL always returns 404, so include it as well.
 10038	OUTOFSCOPE	http://app:8080/todo
 # OIDC isn't configured in the test environment and DEBUG=True so this gives a 500 without CSP headers

--- a/src/zap.conf
+++ b/src/zap.conf
@@ -48,7 +48,9 @@
 10038	OUTOFSCOPE	http://app:8080/public/img/.*
 10038	OUTOFSCOPE	http://app:8080/public/css/.*
 10038	OUTOFSCOPE	http://app:8080/public/js/.*
-10038	OUTOFSCOPE	http://app:8080/(robots.txt|sitemap.xml|TODO|edit|users/)
+10038	OUTOFSCOPE	http://app:8080/(robots.txt|sitemap.xml|TODO|edit/)
+10038	OUTOFSCOPE	http://app:8080/users
+10038	OUTOFSCOPE	http://app:8080/users/add
 # This URL always returns 404, so include it as well.
 10038	OUTOFSCOPE	http://app:8080/todo
 # OIDC isn't configured in the test environment and DEBUG=True so this gives a 500 without CSP headers


### PR DESCRIPTION
# Simple user management #

## 🗣 Description ##

This adds the initial UI for adding users to an approved domain. Using our previous RBAC work, we add a `/domain/<id>/users` view to show the users on the domain and a `/domain/<id>/users/add` form where people can enter an email address to add a user with the "admin" role on that domain. (There is no other role than "admin" right now.)

<img width="999" alt="Screen Shot 2023-03-21 at 2 55 06 PM" src="https://user-images.githubusercontent.com/443389/226726027-ac8c15e3-9d67-44e0-ab86-7106cf3b381a.png">

Currently, users can only add emails that have already been seen as users in our registrar system. In #477 we will extend this functionality to send emails to users who haven't logged in before to invite them to log in. Another limitation is that styling does not yet exactly match what Igor has drawn in Figma, primarily in the user table and breadcrumbs.

## 💭 Motivation and context ##

Closes #461 