### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -47,3 +47,5 @@ def less_console_noise():
         # restore the streams
         for handler in handlers.values():
             handler.setStream(restore[handler.name])
+        # close the file we opened
+        devnull.close()

--- a/src/djangooidc/oidc.py
+++ b/src/djangooidc/oidc.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from Cryptodome.PublicKey.RSA import importKey
 from jwkest.jwk import RSAKey  # type: ignore
-from oic import oic, rndstr
+from oic import oic, rndstr, utils
 from oic.oauth2 import ErrorResponse
 from oic.oic import AuthorizationRequest, AuthorizationResponse, RegistrationResponse
 from oic.oic.message import AccessTokenResponse
@@ -56,7 +56,7 @@ class Client(oic.Client):
                 client_id=None,
                 client_authn_method=CLIENT_AUTHN_METHOD,
                 keyjar=keyjar,
-                verify_ssl=verify_ssl,
+                settings=utils.settings.OicClientSettings(verify_ssl=verify_ssl),
                 config=None,
             )
             # must be set after client is initialized

--- a/src/djangooidc/tests/common.py
+++ b/src/djangooidc/tests/common.py
@@ -47,3 +47,5 @@ def less_console_noise():
         # restore the streams
         for handler in handlers.values():
             handler.setStream(restore[handler.name])
+        # close the file we opened
+        devnull.close()

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -189,6 +189,9 @@ TEMPLATES = [
     },
 ]
 
+# Stop using table-based default form renderer which is deprecated
+FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
+
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 
 # IS_DEMO_SITE controls whether or not we show our big red "TEST SITE" banner

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -469,7 +469,9 @@ class DomainApplication(TimeStampedModel):
         nothing.
         """
         if self.submitter is None or self.submitter.email is None:
-            logger.warning("Cannot send confirmation email, no submitter email address.")
+            logger.warning(
+                "Cannot send confirmation email, no submitter email address."
+            )
             return
         try:
             send_templated_email(

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -469,7 +469,7 @@ class DomainApplication(TimeStampedModel):
         nothing.
         """
         if self.submitter is None or self.submitter.email is None:
-            logger.warn("Cannot send confirmation email, no submitter email address.")
+            logger.warning("Cannot send confirmation email, no submitter email address.")
             return
         try:
             send_templated_email(

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -52,6 +52,8 @@ def less_console_noise():
         # restore the streams
         for handler in handlers.values():
             handler.setStream(restore[handler.name])
+        # close the file we opened
+        devnull.close()
 
 
 class MockUserLogin:

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -30,7 +30,7 @@ class TestDomainApplication(TestCase):
         """Can create with just a creator."""
         user, _ = User.objects.get_or_create()
         application = DomainApplication.objects.create(creator=user)
-        self.assertEquals(application.status, DomainApplication.STARTED)
+        self.assertEqual(application.status, DomainApplication.STARTED)
 
     def test_full_create(self):
         """Can create with all fields."""
@@ -115,13 +115,13 @@ class TestDomain(TestCase):
     def test_minimal_create(self):
         """Can create with just a name."""
         domain = Domain.objects.create(name="igorville.gov")
-        self.assertEquals(domain.is_active, False)
+        self.assertEqual(domain.is_active, False)
 
     def test_get_status(self):
         """Returns proper status based on `is_active`."""
         domain = Domain.objects.create(name="igorville.gov")
         domain.save()
-        self.assertEquals(None, domain.status)
+        self.assertEqual(None, domain.status)
         domain.activate()
         domain.save()
         self.assertIn("ok", domain.status)

--- a/src/registrar/tests/test_signals.py
+++ b/src/registrar/tests/test_signals.py
@@ -19,7 +19,7 @@ class TestUserPostSave(TestCase):
 
     def test_user_created_without_matching_contact(self):
         """Expect 1 Contact containing data copied from User."""
-        self.assertEquals(len(Contact.objects.all()), 0)
+        self.assertEqual(len(Contact.objects.all()), 0)
         user = get_user_model().objects.create(
             username=self.username,
             first_name=self.first_name,
@@ -28,14 +28,14 @@ class TestUserPostSave(TestCase):
             phone=self.phone,
         )
         actual = Contact.objects.get(user=user)
-        self.assertEquals(actual.first_name, self.first_name)
-        self.assertEquals(actual.last_name, self.last_name)
-        self.assertEquals(actual.email, self.email)
-        self.assertEquals(actual.phone, self.phone)
+        self.assertEqual(actual.first_name, self.first_name)
+        self.assertEqual(actual.last_name, self.last_name)
+        self.assertEqual(actual.email, self.email)
+        self.assertEqual(actual.phone, self.phone)
 
     def test_user_created_with_matching_contact(self):
         """Expect 1 Contact associated, but with no data copied from User."""
-        self.assertEquals(len(Contact.objects.all()), 0)
+        self.assertEqual(len(Contact.objects.all()), 0)
         Contact.objects.create(
             first_name=self.preferred_first_name,
             last_name=self.preferred_last_name,
@@ -49,21 +49,21 @@ class TestUserPostSave(TestCase):
             email=self.email,
         )
         actual = Contact.objects.get(user=user)
-        self.assertEquals(actual.first_name, self.preferred_first_name)
-        self.assertEquals(actual.last_name, self.preferred_last_name)
-        self.assertEquals(actual.email, self.email)
-        self.assertEquals(actual.phone, self.preferred_phone)
+        self.assertEqual(actual.first_name, self.preferred_first_name)
+        self.assertEqual(actual.last_name, self.preferred_last_name)
+        self.assertEqual(actual.email, self.email)
+        self.assertEqual(actual.phone, self.preferred_phone)
 
     def test_user_updated_without_matching_contact(self):
         """Expect 1 Contact containing data copied from User."""
         # create the user
-        self.assertEquals(len(Contact.objects.all()), 0)
+        self.assertEqual(len(Contact.objects.all()), 0)
         user = get_user_model().objects.create(
             username=self.username, first_name="", last_name="", email="", phone=""
         )
         # delete the contact
         Contact.objects.all().delete()
-        self.assertEquals(len(Contact.objects.all()), 0)
+        self.assertEqual(len(Contact.objects.all()), 0)
         # modify the user
         user.username = self.username
         user.first_name = self.first_name
@@ -73,15 +73,15 @@ class TestUserPostSave(TestCase):
         user.save()
         # test
         actual = Contact.objects.get(user=user)
-        self.assertEquals(actual.first_name, self.first_name)
-        self.assertEquals(actual.last_name, self.last_name)
-        self.assertEquals(actual.email, self.email)
-        self.assertEquals(actual.phone, self.phone)
+        self.assertEqual(actual.first_name, self.first_name)
+        self.assertEqual(actual.last_name, self.last_name)
+        self.assertEqual(actual.email, self.email)
+        self.assertEqual(actual.phone, self.phone)
 
     def test_user_updated_with_matching_contact(self):
         """Expect 1 Contact associated, but with no data copied from User."""
         # create the user
-        self.assertEquals(len(Contact.objects.all()), 0)
+        self.assertEqual(len(Contact.objects.all()), 0)
         user = get_user_model().objects.create(
             username=self.username,
             first_name=self.first_name,
@@ -97,7 +97,7 @@ class TestUserPostSave(TestCase):
         user.save()
         # test
         actual = Contact.objects.get(user=user)
-        self.assertEquals(actual.first_name, self.first_name)
-        self.assertEquals(actual.last_name, self.last_name)
-        self.assertEquals(actual.email, self.email)
-        self.assertEquals(actual.phone, self.phone)
+        self.assertEqual(actual.first_name, self.first_name)
+        self.assertEqual(actual.last_name, self.last_name)
+        self.assertEqual(actual.email, self.email)
+        self.assertEqual(actual.phone, self.phone)

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -549,9 +549,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # the post request should return a redirect to the contact
         # question
         self.assertEqual(election_result.status_code, 302)
-        self.assertEqual(
-            election_result["Location"], "/register/organization_contact/"
-        )
+        self.assertEqual(election_result["Location"], "/register/organization_contact/")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = election_result.follow()
         self.assertNotContains(contact_page, "Federal agency")

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -153,11 +153,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         type_result = type_page.form.submit()
         # should see results in db
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.organization_type, "federal")
+        self.assertEqual(application.organization_type, "federal")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(type_result.status_code, 302)
-        self.assertEquals(type_result["Location"], "/register/organization_federal/")
+        self.assertEqual(type_result.status_code, 302)
+        self.assertEqual(type_result["Location"], "/register/organization_federal/")
         num_pages_tested += 1
 
         # ---- FEDERAL BRANCH PAGE  ----
@@ -172,11 +172,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         federal_result = federal_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.federal_type, "executive")
+        self.assertEqual(application.federal_type, "executive")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(federal_result.status_code, 302)
-        self.assertEquals(federal_result["Location"], "/register/organization_contact/")
+        self.assertEqual(federal_result.status_code, 302)
+        self.assertEqual(federal_result["Location"], "/register/organization_contact/")
         num_pages_tested += 1
 
         # ---- ORG CONTACT PAGE  ----
@@ -201,17 +201,17 @@ class DomainApplicationTests(TestWithUser, WebTest):
         org_contact_result = org_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.organization_name, "Testorg")
-        self.assertEquals(application.address_line1, "address 1")
-        self.assertEquals(application.address_line2, "address 2")
-        self.assertEquals(application.city, "NYC")
-        self.assertEquals(application.state_territory, "NY")
-        self.assertEquals(application.zipcode, "10002")
-        self.assertEquals(application.urbanization, "URB Royal Oaks")
+        self.assertEqual(application.organization_name, "Testorg")
+        self.assertEqual(application.address_line1, "address 1")
+        self.assertEqual(application.address_line2, "address 2")
+        self.assertEqual(application.city, "NYC")
+        self.assertEqual(application.state_territory, "NY")
+        self.assertEqual(application.zipcode, "10002")
+        self.assertEqual(application.urbanization, "URB Royal Oaks")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(org_contact_result.status_code, 302)
-        self.assertEquals(
+        self.assertEqual(org_contact_result.status_code, 302)
+        self.assertEqual(
             org_contact_result["Location"], "/register/authorizing_official/"
         )
         num_pages_tested += 1
@@ -232,15 +232,15 @@ class DomainApplicationTests(TestWithUser, WebTest):
         ao_result = ao_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.authorizing_official.first_name, "Testy ATO")
-        self.assertEquals(application.authorizing_official.last_name, "Tester ATO")
-        self.assertEquals(application.authorizing_official.title, "Chief Tester")
-        self.assertEquals(application.authorizing_official.email, "testy@town.com")
-        self.assertEquals(application.authorizing_official.phone, "(201) 555 5555")
+        self.assertEqual(application.authorizing_official.first_name, "Testy ATO")
+        self.assertEqual(application.authorizing_official.last_name, "Tester ATO")
+        self.assertEqual(application.authorizing_official.title, "Chief Tester")
+        self.assertEqual(application.authorizing_official.email, "testy@town.com")
+        self.assertEqual(application.authorizing_official.phone, "(201) 555 5555")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(ao_result.status_code, 302)
-        self.assertEquals(ao_result["Location"], "/register/current_sites/")
+        self.assertEqual(ao_result.status_code, 302)
+        self.assertEqual(ao_result["Location"], "/register/current_sites/")
         num_pages_tested += 1
 
         # ---- CURRENT SITES PAGE  ----
@@ -255,14 +255,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         current_sites_result = current_sites_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(
+        self.assertEqual(
             application.current_websites.filter(website="http://www.city.com").count(),
             1,
         )
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(current_sites_result.status_code, 302)
-        self.assertEquals(current_sites_result["Location"], "/register/dotgov_domain/")
+        self.assertEqual(current_sites_result.status_code, 302)
+        self.assertEqual(current_sites_result["Location"], "/register/dotgov_domain/")
         num_pages_tested += 1
 
         # ---- DOTGOV DOMAIN PAGE  ----
@@ -277,14 +277,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         dotgov_result = dotgov_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.requested_domain.name, "city.gov")
-        self.assertEquals(
+        self.assertEqual(application.requested_domain.name, "city.gov")
+        self.assertEqual(
             application.alternative_domains.filter(website="city1.gov").count(), 1
         )
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(dotgov_result.status_code, 302)
-        self.assertEquals(dotgov_result["Location"], "/register/purpose/")
+        self.assertEqual(dotgov_result.status_code, 302)
+        self.assertEqual(dotgov_result["Location"], "/register/purpose/")
         num_pages_tested += 1
 
         # ---- PURPOSE PAGE  ----
@@ -299,11 +299,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         purpose_result = purpose_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.purpose, "For all kinds of things.")
+        self.assertEqual(application.purpose, "For all kinds of things.")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(purpose_result.status_code, 302)
-        self.assertEquals(purpose_result["Location"], "/register/your_contact/")
+        self.assertEqual(purpose_result.status_code, 302)
+        self.assertEqual(purpose_result["Location"], "/register/your_contact/")
         num_pages_tested += 1
 
         # ---- YOUR CONTACT INFO PAGE  ----
@@ -323,15 +323,15 @@ class DomainApplicationTests(TestWithUser, WebTest):
         your_contact_result = your_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.submitter.first_name, "Testy you")
-        self.assertEquals(application.submitter.last_name, "Tester you")
-        self.assertEquals(application.submitter.title, "Admin Tester")
-        self.assertEquals(application.submitter.email, "testy-admin@town.com")
-        self.assertEquals(application.submitter.phone, "(201) 555 5556")
+        self.assertEqual(application.submitter.first_name, "Testy you")
+        self.assertEqual(application.submitter.last_name, "Tester you")
+        self.assertEqual(application.submitter.title, "Admin Tester")
+        self.assertEqual(application.submitter.email, "testy-admin@town.com")
+        self.assertEqual(application.submitter.phone, "(201) 555 5556")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(your_contact_result.status_code, 302)
-        self.assertEquals(your_contact_result["Location"], "/register/other_contacts/")
+        self.assertEqual(your_contact_result.status_code, 302)
+        self.assertEqual(your_contact_result["Location"], "/register/other_contacts/")
         num_pages_tested += 1
 
         # ---- OTHER CONTACTS PAGE  ----
@@ -351,7 +351,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         other_contacts_result = other_contacts_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(
+        self.assertEqual(
             application.other_contacts.filter(
                 first_name="Testy2",
                 last_name="Tester2",
@@ -363,8 +363,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         )
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(other_contacts_result.status_code, 302)
-        self.assertEquals(other_contacts_result["Location"], "/register/anything_else/")
+        self.assertEqual(other_contacts_result.status_code, 302)
+        self.assertEqual(other_contacts_result["Location"], "/register/anything_else/")
         num_pages_tested += 1
 
         # ---- ANYTHING ELSE PAGE  ----
@@ -380,11 +380,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         anything_else_result = anything_else_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.anything_else, "Nothing else.")
+        self.assertEqual(application.anything_else, "Nothing else.")
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(anything_else_result.status_code, 302)
-        self.assertEquals(anything_else_result["Location"], "/register/requirements/")
+        self.assertEqual(anything_else_result.status_code, 302)
+        self.assertEqual(anything_else_result["Location"], "/register/requirements/")
         num_pages_tested += 1
 
         # ---- REQUIREMENTS PAGE  ----
@@ -400,11 +400,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         requirements_result = requirements_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(application.is_policy_acknowledged, True)
+        self.assertEqual(application.is_policy_acknowledged, True)
         # the post request should return a redirect to the next form in
         # the application
-        self.assertEquals(requirements_result.status_code, 302)
-        self.assertEquals(requirements_result["Location"], "/register/review/")
+        self.assertEqual(requirements_result.status_code, 302)
+        self.assertEqual(requirements_result["Location"], "/register/review/")
         num_pages_tested += 1
 
         # ---- REVIEW AND FINSIHED PAGES  ----
@@ -449,8 +449,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         with less_console_noise():
             review_result = review_form.submit()
 
-        self.assertEquals(review_result.status_code, 302)
-        self.assertEquals(review_result["Location"], "/register/finished/")
+        self.assertEqual(review_result.status_code, 302)
+        self.assertEqual(review_result["Location"], "/register/finished/")
         num_pages_tested += 1
 
         # following this redirect is a GET request, so include the cookie
@@ -486,8 +486,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # the post request should return a redirect to the federal branch
         # question
-        self.assertEquals(type_result.status_code, 302)
-        self.assertEquals(type_result["Location"], "/register/organization_federal/")
+        self.assertEqual(type_result.status_code, 302)
+        self.assertEqual(type_result["Location"], "/register/organization_federal/")
 
         # and the step label should appear in the sidebar of the resulting page
         # but the step label for the elections page should not appear
@@ -503,8 +503,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         federal_result = federal_page.form.submit()
         # the post request should return a redirect to the contact
         # question
-        self.assertEquals(federal_result.status_code, 302)
-        self.assertEquals(federal_result["Location"], "/register/organization_contact/")
+        self.assertEqual(federal_result.status_code, 302)
+        self.assertEqual(federal_result["Location"], "/register/organization_contact/")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = federal_result.follow()
         self.assertContains(contact_page, "Federal agency")
@@ -531,8 +531,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         type_result = type_form.submit()
 
         # the post request should return a redirect to the elections question
-        self.assertEquals(type_result.status_code, 302)
-        self.assertEquals(type_result["Location"], "/register/organization_election/")
+        self.assertEqual(type_result.status_code, 302)
+        self.assertEqual(type_result["Location"], "/register/organization_election/")
 
         # and the step label should appear in the sidebar of the resulting page
         # but the step label for the elections page should not appear
@@ -548,8 +548,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         election_result = election_page.form.submit()
         # the post request should return a redirect to the contact
         # question
-        self.assertEquals(election_result.status_code, 302)
-        self.assertEquals(
+        self.assertEqual(election_result.status_code, 302)
+        self.assertEqual(
             election_result["Location"], "/register/organization_contact/"
         )
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
@@ -619,8 +619,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # the post request should return a redirect to the type of work page
         # if it was successful.
-        self.assertEquals(contact_result.status_code, 302)
-        self.assertEquals(contact_result["Location"], "/register/type_of_work/")
+        self.assertEqual(contact_result.status_code, 302)
+        self.assertEqual(contact_result["Location"], "/register/type_of_work/")
 
     def test_application_type_of_work_special(self):
         """Special districts have to answer an additional question."""
@@ -885,7 +885,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.assertIn("current_sites-1-website", current_sites_form.fields)
         # and it is correctly referenced in the ManyToOne relationship
         application = DomainApplication.objects.get()  # there's only one
-        self.assertEquals(
+        self.assertEqual(
             application.current_websites.filter(website="https://example.com").count(),
             1,
         )


### PR DESCRIPTION
# Fix deprecation warnings #

## 🗣 Description ##

In preparation for the upcoming Django 4.2, their docs encourage fixing deprecation warnings. Running our test suite with Python's warnings turned on (`docker compose run app python -Wa manage.py test`) produces many warnings that can fairly trivially be fixed. This PR fixes all of them. (Actually, there is one left: `RemovedInDjango50Warning: The USE_L10N setting is deprecated.` and I can't find any guidance on how to satisfy that deprecation warning. We appear to be correctly using `USE_L10N = True` in our project's settings file.)

## 💭 Motivation and context ##

Good hygiene, I guess?