### PR TITLE
Begin using requirements.txt

### DIFF
--- a/docs/operations/runbooks/update_python_dependencies.md
+++ b/docs/operations/runbooks/update_python_dependencies.md
@@ -1,8 +1,19 @@
 # HOWTO Update Python Dependencies
 ========================
 
-1. Check the [Pipfile](./src/Pipfile) for pinned dependencies and manually adjust the version numbers
-1. Run `cd src`, `docker-compose up -d`, and `docker-compose exec app pipenv update` to perform the upgrade and generate a new [Pipfile.lock](./src/Pipfile.lock) 
+1. Check the [Pipfile](../../../src/Pipfile) for pinned dependencies and manually adjust the version numbers
+
+1. Run
+
+        cd src
+        docker-compose run app bash -c "pipenv lock && pipenv requirements > requirements.txt"
+
+    This will generate a new [Pipfile.lock](../../../src/Pipfile.lock) and create a new [requirements.txt](../../../src/requirements.txt). It will not install anything.
+
+    It is necessary to use `bash -c` because `run pipenv requirements` will not recognize that it is running non-interactively and will include garbage formatting characters.
+
+    The requirements.txt is used by Cloud.gov. It is needed to work around a bug in the CloudFoundry buildpack version of Pipenv that breaks on installing from a git repository.
+
 1. (optional) Run `docker-compose stop` and `docker-compose build` to build a new image for local development with the updated dependencies.
 
-The reason for de-coupling the `build` and `update` steps is to increase consistency between builds and reduce "it works on my laptop!". Therefore, `build` uses the lock file as-is; dependencies are never updated except by explicit choice.
+    The reason for de-coupling the `build` and `lock` steps is to increase consistency between builds--a run of `build` will always get exactly the dependencies listed in `Pipfile.lock`, nothing more, nothing less.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,4 +8,4 @@ COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
 
 RUN pip install pipenv
-RUN pipenv install --system --dev
+RUN pipenv sync --system --dev

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,49 @@
+-i https://pypi.python.org/simple
+asgiref==3.6.0 ; python_version >= '3.7'
+boto3==1.26.69
+botocore==1.29.69 ; python_version >= '3.7'
+cachetools==5.3.0
+certifi==2022.12.7 ; python_version >= '3.6'
+cfenv==0.5.3
+cffi==1.15.1
+charset-normalizer==3.0.1 ; python_version >= '3.6'
+cryptography==39.0.1 ; python_version >= '3.6'
+defusedxml==0.7.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+dj-database-url==1.2.0
+dj-email-url==1.0.6
+django==4.1.6
+django-allow-cidr==0.6.0
+django-auditlog==2.2.2
+django-cache-url==3.4.4
+django-csp==3.7
+django-fsm==2.8.1
+django-phonenumber-field[phonenumberslite]==7.0.2
+django-widget-tweaks==1.4.12
+environs[django]==9.5.0
+faker==17.0.0
+furl==2.1.3
+future==0.18.3 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+gunicorn==20.1.0
+idna==3.4 ; python_version >= '3.5'
+jmespath==1.0.1 ; python_version >= '3.7'
+mako==1.2.4 ; python_version >= '3.7'
+markupsafe==2.1.2 ; python_version >= '3.7'
+marshmallow==3.19.0 ; python_version >= '3.7'
+oic==1.5.0
+orderedmultidict==1.0.1
+packaging==23.0 ; python_version >= '3.7'
+phonenumberslite==8.13.6
+psycopg2-binary==2.9.5
+pycparser==2.21
+pycryptodomex==3.17
+pyjwkest==1.4.2
+python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+python-dotenv==0.21.1 ; python_version >= '3.7'
+requests==2.28.2
+s3transfer==0.6.0 ; python_version >= '3.7'
+setuptools==67.2.0 ; python_version >= '3.7'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+sqlparse==0.4.3 ; python_version >= '3.5'
+typing-extensions==4.4.0 ; python_version >= '3.7'
+urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+whitenoise==6.3.0


### PR DESCRIPTION
What it says on the tin.

> The requirements.txt is used by Cloud.gov. It is needed to work around a bug in the CloudFoundry buildpack version of Pipenv that breaks on installing [packages] from a git repository.