### PR TITLE
Update intro text for requestor contact info

### DIFF
--- a/src/registrar/templates/application_your_contact.html
+++ b/src/registrar/templates/application_your_contact.html
@@ -8,8 +8,7 @@
   changes below. Changing your contact information here won’t affect your login.gov
   account information.</p>
 
-  <p>The contact information you provide here won’t be public and will only be used for
-  the .gov registry.</p>
+  <p>The contact information you provide here won’t be public and will only be used to support your domain request.</p>
 {% endblock %}
 
 

--- a/src/registrar/templates/application_your_contact.html
+++ b/src/registrar/templates/application_your_contact.html
@@ -5,7 +5,7 @@
   <p>We’ll use this information to contact you about your domain request.</p>
 
   <p>If you’d like us to use a different name, email, or phone number you can make those
-  changes below. Changing your contact information here won’t affect your login.gov
+  changes below. Changing your contact information here won’t affect your Login.gov
   account information.</p>
 
   <p>The contact information you provide here won’t be public and will only be used to support your domain request.</p>


### PR DESCRIPTION
# Update intro text for requestor contact info #

## 🗣 Description ##

- Removed text about contact info being used for the registry
- login.gov should be Login.gov
