### PR TITLE
Remove wait flag from CloudFoundry commands

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -35,4 +35,4 @@ jobs:
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-getgov-prototyping
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --wait --command 'python manage.py migrate' --name migrate"
+          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"

--- a/.github/workflows/reset-db.yaml
+++ b/.github/workflows/reset-db.yaml
@@ -36,7 +36,7 @@ jobs:
           cf_password: ${{ secrets[CF_PASSWORD] }}
           cf_org: cisa-getgov-prototyping
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --wait --command 'python manage.py flush --no-input' --name flush"
+          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py flush --no-input' --name flush"
 
       - name: Load fake data for ${{ github.event.inputs.environment }}
         uses: 18f/cg-deploy-action@main
@@ -45,4 +45,4 @@ jobs:
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-getgov-prototyping
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --wait --command 'python manage.py load' --name loaddata"
+          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py load' --name loaddata"

--- a/docs/developer/database-access.md
+++ b/docs/developer/database-access.md
@@ -24,7 +24,7 @@ cf run-task getgov-ENVIRONMENT --command 'python manage.py migrate' --name migra
 Optionally, load data from fixtures as well
 
 ```shell
-cf run-task getgov-ENVIRONMENT --wait --command 'python manage.py load' --name loaddata
+cf run-task getgov-ENVIRONMENT --command 'python manage.py load' --name loaddata
 ```
 
 For the `stable` environment, developers don't have credentials so we need to


### PR DESCRIPTION
## 🗣 Description ##

Removes wait flag from `run-task` commands. This commit can be reverted once the regression which broke `--wait` is fixed.

## 💭 Motivation and context ##

See this issue: https://github.com/cloudfoundry/cli/issues/2238