### PR TITLE
Fix Pa11y Github Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,9 +43,15 @@ jobs:
         run: |
           perl -pi \
           -e 's/"csp.middleware.CSPMiddleware",/$&"registrar.tests.common.MockUserLogin",/' \
-          src/registrar/config/settings.py
+          /registrar/config/settings.py
 
-      - name: Accessibility Scan
+      - name: Start container
         working-directory: ./src
         # leverage the docker compose setup that we already have for local development
-        run: docker compose run pa11y npm run pa11y-ci
+        run: docker compose up -d 
+
+      - name: run pa11y
+        working-directory: ./src
+        run: |
+          npm i -g pa11y-ci
+          pa11y-ci 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           perl -pi \
           -e 's/"csp.middleware.CSPMiddleware",/$&"registrar.tests.common.MockUserLogin",/' \
-          /registrar/config/settings.py
+          registrar/config/settings.py
 
       - name: Start container
         working-directory: ./src

--- a/src/.pa11yci
+++ b/src/.pa11yci
@@ -1,22 +1,28 @@
 {
+    "defaults": {
+        "concurrency": 1,
+        "timeout": 10000,
+        "hideElements": "a[href='/whoami/']"
+
+    },
     "urls": [
-        "http://app:8080/",
-        "http://app:8080/health/",
-        "http://app:8080/whoami/",
-        "http://app:8080/register/",
-        "http://app:8080/register/organization/",
-        "http://app:8080/register/org_federal/",
-        "http://app:8080/register/org_election/",
-        "http://app:8080/register/org_contact/",
-        "http://app:8080/register/authorizing_official/",
-        "http://app:8080/register/current_sites/",
-        "http://app:8080/register/dotgov_domain/",
-        "http://app:8080/register/purpose/",
-        "http://app:8080/register/your_contact/",
-        "http://app:8080/register/other_contacts/",
-        "http://app:8080/register/anything_else/",
-        "http://app:8080/register/requirements/",
-        "http://app:8080/register/review/",
-        "http://app:8080/register/finished/"
+        "http://localhost:8080/",
+        "http://localhost:8080/health/",
+        "http://localhost:8080/whoami/",
+        "http://localhost:8080/register/",
+        "http://localhost:8080/register/organization/",
+        "http://localhost:8080/register/org_federal/",
+        "http://localhost:8080/register/org_election/",
+        "http://localhost:8080/register/org_contact/",
+        "http://localhost:8080/register/authorizing_official/",
+        "http://localhost:8080/register/current_sites/",
+        "http://localhost:8080/register/dotgov_domain/",
+        "http://localhost:8080/register/purpose/",
+        "http://localhost:8080/register/your_contact/",
+        "http://localhost:8080/register/other_contacts/",
+        "http://localhost:8080/register/anything_else/",
+        "http://localhost:8080/register/requirements/",
+        "http://localhost:8080/register/review/",
+        "http://localhost:8080/register/finished/"
     ]
 }


### PR DESCRIPTION
## 🗣 Description ##

This PR updates our GH action for pa11y-ci, running pa11y outside the docker container. This gets pa11y to run again, as it has been quietly failing in our workflow (failing to run, but showing up as a checkmark in the workflow). 

A slight disadvantage of this approach is that there is potential for the environment the test is run in to be less consistent than it would have been inside of a docker container. The advantage of this approach is that we are able to actually run it without the puppeteer issues that are present when trying to run it from within the container.

A good indication that the tests are running properly is that we did get some errors showing up, prior to adding an ignore rule to the configuration file:

![Screen Shot 2023-04-18 at 4 55 58 PM](https://user-images.githubusercontent.com/52677065/232914122-57b5007f-f326-4132-bdb0-02d7c93c1f41.png)


Special thanks to the engineers over on the FAC project [documenting the problem](https://github.com/GSA-TTS/FAC/issues/711) in their issues and having a [config](https://github.com/GSA-TTS/FAC/pull/862) we can reference.


## 💭 Motivation and context ##

Closes #518 