### PR TITLE
Fix puppeteer crashing error

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       - POSTGRES_PASSWORD=feedabee
 
   node:
+    build:
+      context: .
+      dockerfile: node.Dockerfile
     image: node
     volumes:
       - .:/app


### PR DESCRIPTION
# Fix Puppeteer crashing Node container #

## 🗣 Description ##
Changes the node container to also use the node.dockerfile (which says which browsers to use) just as the pa11y container does. 

## 💭 Motivation and context ##
On my mac, "docker-compose up" kept resulting in node crashing due to the chromium dependency of puppeteer.  Online it seemed most people having this issue were calling out they had an M1 chip Mac and that the chromium dependency puppeteer uses is missing files that are needed on M1s but not others. 
Original error output that this fixes.
![image](https://user-images.githubusercontent.com/109625347/236585985-e33af707-ddc9-4721-bbc8-af169514a8b2.png)

See [this slack thread for more detail](https://cisa-corp.slack.com/archives/C03QM0JGSQG/p1683230458692039)


Note to developers: double check that this doesn't just fix it on my machine but cause a bug on yours, I would suggest deleting your docker image completely and make sure it rebuilds and runs just fine with this new change.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->