### PR TITLE
Update README with steps on accessing /admin

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -36,7 +36,7 @@ You'll need to create the `.env` file yourself. Get the secrets from Cloud.gov b
 
 ## Adding user to /admin
 
-To be able to view and use /admin locally:
+The endpoint /admin can be used to view and manage site content, including but not limited to user information and the list of current applications in the database. To be able to view and use /admin locally:
 
 1. Login via login.gov
 2. Go to the home page and make sure you can see the part where you can submit an application
@@ -53,6 +53,8 @@ To be able to view and use /admin locally:
         ...
  ]
 ```
+
+5. In the browser, navigate to /admins. To verify that all is working correctly, under "domain applications" you should see fake domains with various fake statuses.
 
 ## Viewing Logs
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -34,6 +34,26 @@ DJANGO_SECRET_LOGIN_KEY="<...>"
 
 You'll need to create the `.env` file yourself. Get the secrets from Cloud.gov by running `cf env getgov-YOURSANDBOX`. More information is available in [rotate_application_secrets.md](../operations/runbooks/rotate_application_secrets.md).
 
+## Adding user to /admin
+
+To be able to view and use /admin locally:
+
+1. Login via login.gov
+2. Go to the home page and make sure you can see the part where you can submit an application
+3. Go to /admin and it will tell you that UUID is not authorized, copy that UUID for use in 4
+4. in src/registrar/fixtures.py add to the ADMINS list in that file by adding your UUID as your username along with your first and last name. See below:
+
+```
+ ADMINS = [
+        {
+            "username": "<UUID here>",
+            "first_name": "",
+            "last_name": "",
+        },
+        ...
+ ]
+```
+
 ## Viewing Logs
 
 If you run via `docker-compose up`, you'll see the logs in your terminal.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Added the steps needed to give oneself access to admin locally 

## 💭 Motivation and context ##

Both Rachid and I had questions on how to do this, so it seems like people onboarding in the future may have the same question and that it warrants documenting. 