### PR TITLE
Resize CISA logo in identifier

### DIFF
--- a/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
+++ b/src/registrar/assets/sass/_theme/_uswds-theme-custom-styles.scss
@@ -417,6 +417,10 @@ footer {
   color: color('primary');
 }
 
+.usa-identifier__logo {
+ height: units(7);
+}
+
 abbr[title] {
   // workaround for underlining abbr element
   border-bottom: none;

--- a/src/registrar/templates/includes/footer.html
+++ b/src/registrar/templates/includes/footer.html
@@ -52,7 +52,7 @@
               src="{% static 'img/CISA_logo.png' %}"
               alt="CISA logo"
               role="img"
-              width="48px"
+              width="56px"
           /></a>
         </div>
         <section


### PR DESCRIPTION
## 🗣 Description ##

Small PR to resize the CISA logo in the identifier so that it matches the size of the logo on get.gov

![image](https://github.com/cisagov/getgov/assets/52677065/30f6a921-794c-4742-a8f4-b8c615ccd96b)
