### PR TITLE
Add sleep and increase timeout for pa11y github action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,5 +53,6 @@ jobs:
       - name: run pa11y
         working-directory: ./src
         run: |
+          sleep 10;
           npm i -g pa11y-ci
           pa11y-ci 

--- a/src/.pa11yci
+++ b/src/.pa11yci
@@ -1,7 +1,7 @@
 {
     "defaults": {
         "concurrency": 1,
-        "timeout": 20000,
+        "timeout": 30000,
         "hideElements": "a[href='/whoami/']"
 
     },

--- a/src/.pa11yci
+++ b/src/.pa11yci
@@ -1,7 +1,7 @@
 {
     "defaults": {
         "concurrency": 1,
-        "timeout": 10000,
+        "timeout": 20000,
         "hideElements": "a[href='/whoami/']"
 
     },


### PR DESCRIPTION
## 🗣 Description ##

This PR adjusts the pa11y test getting up action to try and fix pa11y failing to connect and run on some pages. 

The PR adds a sleep step and increases the timeout in pa11y's config to try and make sure that the server in the docker container is up and running.