### PR TITLE
Audit workflow paths-ignore

### DIFF
--- a/.github/workflows/deploy-stable.yaml
+++ b/.github/workflows/deploy-stable.yaml
@@ -7,6 +7,8 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+      - '**.md'
+      - '.gitignore'
       
     tags:
       - v*

--- a/.github/workflows/security-check.yaml
+++ b/.github/workflows/security-check.yaml
@@ -4,9 +4,15 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+      - '**.md'
+      - '.gitignore'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.gitignore'
     branches:
       - main
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,7 @@ on:
       - '.gitignore'
     branches:
       - main
+      - bl-audit-paths-ignore
 
 jobs:
   python-linting:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ on:
       - '.gitignore'
     branches:
       - main
-      - bl-audit-paths-ignore
 
 jobs:
   python-linting:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,15 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+      - '**.md'
+      - '.gitignore'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.gitignore'
     branches:
       - main
 

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,10 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# OWASP
+zap.yaml
+zap_report.html
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Updates actions to ignore paths on PR-initiated workflows


Aside: Also updates .gitignore to ignore output from running owasp check locally, so that it is not accidentally checked in

## 💭 Motivation and context ##

Reduces the time required for repo changes that don't involve source code modification
Reduces exposure of non-source-code changes to flaky tests (if any)

## ❔ Questions

- [ ] Are there any reasons we'd still want tests to run against changes to something like the README? (Currently attempting to ignore)
- [x] Are there repository settings that require certain checks to run, which will prevent a documentation-only PR from being merged, or will the skipped workflow still register as a "successfully completed" for those purposes?
  - See  #614, jobs are skipped entirely
  - However, this repo does not require any workflow steps explicitly, so this should not be a problem (documentation only PRs will _not_ be blocked by status checks that are not run)