### PR TITLE
Add code owners instructions and added to owners list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # For more information on CODEOWNERS, see the documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @abroddrick
-docs/* @DotGov
+docs/* @cisagov/dotgov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # For more information on CODEOWNERS, see the documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Default owners for all files
 * @abroddrick
+
+# Owners for documentation
 docs/* @cisagov/dotgov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # For more information on CODEOWNERS, see the documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-docs/* @dotgov
+* @abroddrick
+docs/* @DotGov

--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -34,6 +34,8 @@ cf login -a api.fr.cloud.gov  --sso
 
  **Note:** As mentioned in the [Login documentation](https://developers.login.gov/testing/), the sandbox Login account is different account from your regular, production Login account. If you have not created a Login account for the sandbox before, you will need to create a new account first.
 
+- [ ] Optional- add yourself as a codeowner if desired. See the [Developer readme](https://github.com/cisagov/getgov/blob/main/docs/developer/README.md) for how to do this and what it does.
+
 ### Steps for the onboarder
 - [ ] Add the onboardee to cloud.gov org (cisa-getgov-prototyping) 
 - [ ] Setup a [developer specific space for the new developer](#setting-up-developer-sandbox)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -81,6 +81,19 @@ The endpoint /admin can be used to view and manage site content, including but n
 
 5. In the browser, navigate to /admins. To verify that all is working correctly, under "domain applications" you should see fake domains with various fake statuses.
 
+## Adding to CODEOWNERS (optional)
+
+The CODEOWNERS file set the tagged individuals as default PR reviewers on any commit regarding the content specify. "*" indicates a user will be added as PR reviewer for all files in the repo, while "subfolder/*" indicates a particular folder for which a user(s) will be added as default PR reviewer. To add yourself as code owner for all files:
+
+1. Go to .github\CODEOWNERS
+2. where you see "* @abroddrick" add a space followed by your github tag. For instance if your github username was @NewGithubUsername you would do the following:
+
+```
+* @abroddrick @NewGithubUsername
+```
+
+3. Create a pull request to finalize your changes
+
 ## Viewing Logs
 
 If you run via `docker-compose up`, you'll see the logs in your terminal.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -83,14 +83,17 @@ The endpoint /admin can be used to view and manage site content, including but n
 
 ## Adding to CODEOWNERS (optional)
 
-The CODEOWNERS file sets the tagged individuals as default PR reviewers on any commit regarding the content specified. An asterisk indicates a user will be added as PR reviewer for all files in the repo, while "subfolder/*" indicates a particular folder for which a user(s) will be added as default PR reviewer. To add yourself as code owner for all files:
+The CODEOWNERS file sets the tagged individuals as default reviewers on any Pull Request that changes files that they are marked as owners of.
 
-1. Go to .github\CODEOWNERS
-2. where you see "* @abroddrick" add a space followed by your github tag. For instance if your github username was @NewGithubUsername you would do the following:
+1. Go to [.github\CODEOWNERS](../../.github/CODEOWNERS)
+2. Following the [CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), add yourself as owner to files that you wish to be automatically requested as reviewer for.
+   
+   For example, if you wish to add yourself as a default reviewer for all pull requests, add your GitHub username to the same line as the `*` designator:  
 
-```
-* @abroddrick @NewGithubUsername
-```
+   ```diff
+   - * @abroddrick
+   + * @abroddrick @YourGitHubUser
+   ```
 
 3. Create a pull request to finalize your changes
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -83,7 +83,7 @@ The endpoint /admin can be used to view and manage site content, including but n
 
 ## Adding to CODEOWNERS (optional)
 
-The CODEOWNERS file set the tagged individuals as default PR reviewers on any commit regarding the content specify. "*" indicates a user will be added as PR reviewer for all files in the repo, while "subfolder/*" indicates a particular folder for which a user(s) will be added as default PR reviewer. To add yourself as code owner for all files:
+The CODEOWNERS file sets the tagged individuals as default PR reviewers on any commit regarding the content specified. An asterisk indicates a user will be added as PR reviewer for all files in the repo, while "subfolder/*" indicates a particular folder for which a user(s) will be added as default PR reviewer. To add yourself as code owner for all files:
 
 1. Go to .github\CODEOWNERS
 2. where you see "* @abroddrick" add a space followed by your github tag. For instance if your github username was @NewGithubUsername you would do the following:


### PR DESCRIPTION

## 🗣 Description ##

-added instructions in the developer readme for adding to codeowners
-additional  optional checkbox added for onboarding
-udpated codeowners with my tag and updated the current dotgov tag that was inaccurate

## 💭 Motivation and context ##
-it was brought up in a meeting that the tech lead should be added on all PRs and codeowners then should be updated
[See slack thread for context](https://cisa-corp.slack.com/archives/C03QM0JGSQG/p1684348045030259)