### PR TITLE
added link for name/mailing address in sidebar

### DIFF
--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -26,6 +26,15 @@
         <a href="{{ url }}"
           {% if request.path == url %}class="usa-current"{% endif %}
         >
+            Organization name and mailing address
+        </a>
+      </li>      
+
+      <li class="usa-sidenav__item">
+        {% url 'todo' as url %}
+        <a href="{{ url }}"
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
             Authorizing official
         </a>
       </li>


### PR DESCRIPTION
Sidebar update to add "Organization and Mailing Address"
🗣 Description
a minor update to the sidebar for organization and mailing address

💭 Motivation and context
The design have been updated with sidebar, so I am going ahead and update the sidebar.
This will also help with ticket https://github.com/cisagov/getgov/issues/517

(this was from older PR apparently the branch forgot the slash)