### PR TITLE
Update banner text

### DIFF
--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -61,18 +61,13 @@
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 
   {% if IS_DEMO_SITE %}
-    <section
-    class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-icon"
-    aria-label="Site alert"
-    >
-      <div class="usa-alert">
-        <div class="usa-alert__body">
-          <p class="usa-alert__text">
-          <strong>BETA SITE:</strong> We’re building a new way to get a .gov. Take a look around, but don’t rely on this site yet. This site is for testing purposes only. Don’t enter real data into any form on this site. To learn about requesting a .gov domain, visit <a href="https://get.gov" class="usa-link">get.gov</a>
-          </p>
-        </div>
+      <div class="usa-alert usa-alert--warning usa-alert--no-icon">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">
+        <strong>BETA SITE:</strong> We’re building a new way to get a .gov. Take a look around, but don’t rely on this site yet. This site is for testing purposes only. Don’t enter real data into any form on this site. To learn about requesting a .gov domain, visit <a href="https://get.gov" class="usa-link">get.gov</a>
+        </p>
       </div>
-    </section>
+    </div>
   {% endif %}
 
   <section class="usa-banner" aria-label="Official website of the United States government">

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -61,6 +61,7 @@
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 
   {% if IS_DEMO_SITE %}
+  <section aria-label="Alert" >
       <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
@@ -68,6 +69,7 @@
         </p>
       </div>
     </div>
+       </section>
   {% endif %}
 
   <section class="usa-banner" aria-label="Official website of the United States government">

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -68,7 +68,7 @@
       <div class="usa-alert">
         <div class="usa-alert__body">
           <p class="usa-alert__text">
-            <strong>TEST SITE</strong> - Do not use real personal information. Demo purposes only.
+          <strong>BETA SITE:</strong> We’re building a new way to get a .gov. Take a look around, but don’t rely on this site yet. This site is for testing purposes only. Don’t enter real data into any form on this site. To learn about requesting a .gov domain, visit <a href="https://get.gov" class="usa-link">get.gov</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
# Update banner text to match beta site #

## 🗣 Description ##

We'd like both the beta site and the app to have the same banner text. I'm not sure why the text isn't extending across the top of the page as on https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/mr/banner-update/. I don't want to mess with it too much while Igor is out.