### PR TITLE
Form for editing authorizing official

### DIFF
--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -84,6 +84,11 @@ urlpatterns = [
         name="domain-nameservers",
     ),
     path(
+        "domain/<int:pk>/authorizing-official",
+        views.DomainAuthorizingOfficialView.as_view(),
+        name="domain-authorizing-official",
+    ),
+    path(
         "domain/<int:pk>/users/add",
         views.DomainAddUserView.as_view(),
         name="domain-users-add",

--- a/src/registrar/forms/__init__.py
+++ b/src/registrar/forms/__init__.py
@@ -1,2 +1,2 @@
 from .application_wizard import *
-from .domain import DomainAddUserForm, NameserverFormset
+from .domain import DomainAddUserForm, NameserverFormset, ContactForm

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -3,6 +3,9 @@
 from django import forms
 from django.forms import formset_factory
 
+from phonenumber_field.widgets import RegionalPhoneNumberWidget
+
+from ..models import Contact
 
 class DomainAddUserForm(forms.Form):
 
@@ -22,3 +25,40 @@ NameserverFormset = formset_factory(
     DomainNameserverForm,
     extra=1,
 )
+
+
+class ContactForm(forms.ModelForm):
+
+    """Form for updating contacts."""
+
+    class Meta:
+        model = Contact
+        fields = ["first_name", "middle_name", "last_name", "title", "email", "phone"]
+        widgets = {
+            "first_name": forms.TextInput,
+            "middle_name": forms.TextInput,
+            "last_name": forms.TextInput,
+            "title": forms.TextInput,
+            "email": forms.EmailInput,
+            "phone": RegionalPhoneNumberWidget,
+        }
+
+    # the database fields have blank=True so ModelForm doesn't create
+    # required fields by default. Use this list in __init__ to mark each
+    # of these fields as required
+    required = [
+        "first_name",
+        "last_name",
+        "title",
+        "email",
+        "phone"
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # take off maxlength attribute for the phone number field
+        # which interferes with out input_with_errors template tag
+        self.fields['phone'].widget.attrs.pop('maxlength', None)
+
+        for field_name in self.required:
+            self.fields[field_name].required = True

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -20,6 +20,7 @@ class Contact(TimeStampedModel):
         null=True,
         blank=True,
         help_text="First name",
+        verbose_name="first name / given name",
         db_index=True,
     )
     middle_name = models.TextField(
@@ -31,12 +32,14 @@ class Contact(TimeStampedModel):
         null=True,
         blank=True,
         help_text="Last name",
+        verbose_name="last name / family name",
         db_index=True,
     )
     title = models.TextField(
         null=True,
         blank=True,
         help_text="Title",
+        verbose_name="title or role in your organization",
     )
     email = models.TextField(
         null=True,

--- a/src/registrar/templates/domain_authorizing_official.html
+++ b/src/registrar/templates/domain_authorizing_official.html
@@ -1,0 +1,43 @@
+{% extends "domain_base.html" %}
+{% load static field_helpers%}
+
+{% block title %}Domain authorizing official | {{ domain.name }} | {% endblock %}
+
+{% block domain_content %}
+  {# this is right after the messages block in the parent template #}
+  {% include "includes/form_errors.html" with form=form %}
+
+  <h1>Authorizing official</h1>
+
+  <p>Your authorizing official is the person within your organization who can
+  authorize domain requests. This is generally the highest-ranking or
+  highest-elected official in your organization. <a class="usa-link"
+    href="https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/site/cisagov/getgov-home/domains/eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization">Read more about who can serve
+    as an authorizing official.</a></p>
+
+  {% include "includes/required_fields.html" %}
+
+  <form class="usa-form usa-form--large" method="post" novalidate id="form-container">
+    {% csrf_token %}
+
+    {% input_with_errors form.first_name %}
+
+    {% input_with_errors form.middle_name %}
+
+    {% input_with_errors form.last_name %}
+
+    {% input_with_errors form.title %}
+
+    {% input_with_errors form.email %}
+
+    {% input_with_errors form.phone %}
+
+
+
+    <button
+          type="submit"
+          class="usa-button"
+      >Save</button>
+    </form>
+
+{% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -31,7 +31,7 @@
       </li>      
 
       <li class="usa-sidenav__item">
-        {% url 'todo' as url %}
+        {% url 'domain-authorizing-official' pk=domain.id as url %}
         <a href="{{ url }}"
           {% if request.path == url %}class="usa-current"{% endif %}
         >

--- a/src/registrar/views/__init__.py
+++ b/src/registrar/views/__init__.py
@@ -1,6 +1,7 @@
 from .application import *
 from .domain import (
     DomainView,
+    DomainAuthorizingOfficialView,
     DomainNameserversView,
     DomainUsersView,
     DomainAddUserView,

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -12,7 +12,7 @@ from django.views.generic.edit import DeleteView, FormMixin
 
 from registrar.models import Domain, DomainInvitation, User, UserDomainRole
 
-from ..forms import DomainAddUserForm, NameserverFormset
+from ..forms import DomainAddUserForm, NameserverFormset, ContactForm
 from ..utility.email import send_templated_email, EmailSendingError
 from .utility import DomainPermission
 
@@ -27,6 +27,49 @@ class DomainView(DomainPermission, DetailView):
     model = Domain
     template_name = "domain_detail.html"
     context_object_name = "domain"
+
+
+class DomainAuthorizingOfficialView(DomainPermission, FormMixin, DetailView):
+
+    """Domain authorizing official editing view."""
+
+    model = Domain
+    template_name = "domain_authorizing_official.html"
+    context_object_name = "domain"
+    form_class = ContactForm
+
+    def get_form_kwargs(self, *args, **kwargs):
+        """Add domain_info.authorizing_official instance to make a bound form."""
+        form_kwargs = super().get_form_kwargs(*args, **kwargs)
+        form_kwargs["instance"] = self.get_object().domain_info.authorizing_official
+        return form_kwargs
+
+    def get_success_url(self):
+        """Redirect to the overview page for the domain."""
+        return reverse("domain-authorizing-official", kwargs={"pk": self.object.pk})
+
+    def post(self, request, *args, **kwargs):
+        """Form submission posts to this view.
+
+        This post method harmonizes using DetailView and FormMixin together.
+        """
+        self.object = self.get_object()
+        form = self.get_form()
+        if form.is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
+    def form_valid(self, form):
+        """The form is valid, save the authorizing official."""
+        domain = self.get_object()
+        form.save()
+
+        messages.success(
+            self.request, "The authorizing official for this domain has been updated."
+        )
+        # superclass has the redirect
+        return super().form_valid(form)
 
 
 class DomainNameserversView(DomainPermission, FormMixin, DetailView):


### PR DESCRIPTION
# Add form to edit and approved domain's authorizing official information #

## 🗣 Description ##

This adds a page for `/domain/<id>/authorizing-official` where users can edit the name and contact information for the domain's authorizing official.

![Screenshot 2023-05-22 at 12 17 44 PM](https://github.com/cisagov/getgov/assets/443389/028ca86e-4f22-4a4d-9cfa-afb7003e33f6)

The implementation uses a `ContactForm` class that we should be able to re-use for #520. It uses bound forms where the `ContactForm` gets connected up with the domain's `domain.domain_info.authorizing_official` `Contact` object for editing purposes.

Currently, we create new `Contact` objects (https://github.com/cisagov/getgov/blob/a3606d6497bdf85cb132f50ec4aa580613d27f1c/src/registrar/forms/application_wizard.py#L358) for a domain's authorizing official as the domain is being applied for. This means that editing the domain's `authorizing_official` object should only affect the contact information for that individual domain. It should not change the contact information for any other user or domain, but editing that object directly rather than making a new `Contact` and replacing it for the domain raises a possibility that we should be alert for in the future. I don't have a better idea for how to do it more resiliently and it's at least possible that this is the Right Way™️ to do it.

## 💭 Motivation and context ##

Closes #519 