### PR TITLE
Add bug issue template example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,5 @@
+name: Bug
+description: Report a bug
+title: "[Bug]: "
+labels: ["bug"]
+

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,3 +3,46 @@ description: Report a bug
 title: "[Bug]: "
 labels: ["bug"]
 
+body:
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current Behavior
+      description: "Please add a concise description of the issue"
+      placeholder: "Example: The application shows an internal server error when attempting to apply for a new domain"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: "Please add a concise description of the behavior you would expect if this issue were not occurring"
+      placeholder: "Example: When submitting a new domain application, the request should be successful, OR if there is a problem with the user's application preventing submission, errors should be enumerated to the user"
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: "How can the issue be reliably reproduced?"
+      placeholder: |
+        Example:
+        1. In the test environment, fill out the application for a new domain
+        2. Click the button to trigger a save/submit on the final page and complete the application 
+        3. See the error
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "Where is this issue occurring? If related to development environment, list the specific relevant tool versions"
+      placeholder: |
+        Example:
+        - Browser: Chrome x.y.z
+        - Python: x.y.z
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: "Please include additional references, screenshots, documentation that are relevant"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,4 +45,4 @@ body:
     id: additional-context
     attributes:
       label: Additional Context
-      description: "Please include additional references, screenshots, documentation that are relevant"
+      description: "Please include additional references, screenshots, documentation, etc. that are relevant"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Adds an example (or actual, if we want to use it, pending review) bug template

## 💭 Motivation and context ##

Demonstrate why a separate issue template for bugs might be helpful
Enables issue reporters to fill out a form specifically for bugs
Related to changes in #628


Not exactly how it will show up as the _actual_ issue form, but close enough to paint the picture:

<img width="429" alt="image" src="https://github.com/cisagov/getgov/assets/15805554/b8c31efd-a71d-46eb-a246-30b18881f379">
