### PR TITLE
Bug fix: Update sr-only tag to match the section its in

### DIFF
--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -22,7 +22,7 @@
     <h2>Registered domains</h2>
     {% if domains %}
     <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
-      <caption class="sr-only">Your domain applications</caption>
+      <caption class="sr-only">Your registered domains</caption>
       <thead>
         <tr>
           <th data-sortable scope="col" role="columnheader">Domain name</th>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The table for the registered domains on the home page had the same screen reader text as the domain application table; when instead it needs to indicated that it is the table for registered domains.

## 💭 Motivation and context ##
Just a minor bug fix that seemed easier to fix then to make a new backlog ticket. Seamus found it during our meeting