### PR TITLE
Improve bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,25 +24,30 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to Reproduce
-      description: "How can the issue be reliably reproduced? feel free to include screenshots or other supporting artifacts"
-      placeholder: |
+      description: |
+        How can the issue be reliably reproduced? Feel free to include screenshots or other supporting artifacts
+        
         Example:
         1. In the test environment, fill out the application for a new domain
         2. Click the button to trigger a save/submit on the final page and complete the application 
         3. See the error
+      value: |
+        1.
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
-      label: Environment
-      description: "Where is this issue occurring? If related to development environment, list the specific relevant tool versions"
-      placeholder: |
+      label: Environment (optional)
+      description: |
+        Where is this issue occurring? If related to development environment, list the relevant tool versions.
+        
         Example:
+        - Environment: Sandbox
         - Browser: Chrome x.y.z
         - Python: x.y.z
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Context
+      label: Additional Context (optional)
       description: "Please include additional references, screenshots, documentation, etc. that are relevant"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,9 @@ body:
   - type: markdown
     id: help
     attributes:
-      value: GitHub Issues use [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for formatting.
+      value: |
+        > **Note**
+        > GitHub Issues use [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for formatting.
   - type: textarea
     id: current-behavior
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,6 +4,10 @@ title: "[Bug]: "
 labels: ["bug"]
 
 body:
+  - type: markdown
+    id: help
+    attributes:
+      value: GitHub Issues use [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for formatting.
   - type: textarea
     id: current-behavior
     attributes:


### PR DESCRIPTION
## 🗣 Description ##

Iterate on the first pass of the bug issue template:
- Instead of placeholder text for fields where a specific format is desired, place examples in description so that it is easier to copy past (if desired), and so that the example doesn't go away when a user starts typing
  - Note: We did not opt for default value, because deleting content and replacing it is just as annoying/cumbersome
- Mark optional fields more clearly as (optional)

## 💭 Motivation and context ##

We want issue templates to be as ergonomic as possible, as the time spent now will pay dividends when folks are more easily able to contribute quality issues with relevant details.