### PR TITLE
Create SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,3 +1,5 @@
-If you've found a security or privacy issue on the .gov top-level domain infrastructure, email dotgov@cisa.dhs.gov.
+* If you've found a security or privacy issue on the **.gov top-level domain infrastructure**, submit it to our [vulnerabilty disclosure form](https://forms.office.com/Pages/ResponsePage.aspx?id=bOfNPG2UEkq7evydCEI1SqHke9Gh6wJEl3kQ5EjWUKlUMTZZS1lBVkxHUzZURFpLTkE2NEJFVlhVRi4u) or email dotgov@cisa.dhs.gov.
+* If you see a security or privacy issue on **an individual .gov domain**, check [current-full.csv](https://flatgithub.com/cisagov/dotgov-data/blob/main/?filename=current-full.csv) or [Whois](https://domains.dotgov.gov/dotgov-web/registration/whois.xhtml) (same data) to check whether the domain has a security contact to report your finding directly. You are welcome to Cc dotgov@cisa.dhs.gov on the email.
+  * If you are unable to find a contact or receive no response from the security contact, email dotgov@cisa.dhs.gov.
 
-If you see a security or privacy issue on a .gov domain, check [current-full.csv]([url](https://github.com/cisagov/dotgov-data/blob/main/current-full.csv)) or whois (same data) to see if the domain has a security contact. Most [federal (executive branch) agencies]([url](https://github.com/cisagov/vdp-in-fceb/)) also have a vulnerability disclosure policy. If you are unable to find a contact or receive no response from the security contact, you may email dotgov@cisa.dhs.gov.
+Note that most federal (executive branch) agencies maintain a [vulnerability disclosure policy](https://github.com/cisagov/vdp-in-fceb/).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+If you've found a security or privacy issue on the .gov top-level domain infrastructure, email dotgov@cisa.dhs.gov.
+
+If you see a security or privacy issue on a .gov domain, check [current-full.csv]([url](https://github.com/cisagov/dotgov-data/blob/main/current-full.csv)) or whois (same data) to see if the domain has a security contact. Most [federal (executive branch) agencies]([url](https://github.com/cisagov/vdp-in-fceb/)) also have a vulnerability disclosure policy. If you are unable to find a contact or receive no response from the security contact, you may email dotgov@cisa.dhs.gov.


### PR DESCRIPTION
The cisagov GitHub org's security policy default is a highly mediated path back to us. This change adds a clearer way for people who want to report security issues to the .gov registry.