### PR TITLE
Fixes #524- Election office now doesnt show up when selected School District

### DIFF
--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -562,6 +562,7 @@ class DomainApplication(TimeStampedModel):
         """Show this step if the answer to the first question implies it.
 
         This shows for answers that aren't "Federal" or "Interstate".
+        This also doesnt show if user selected "School District" as well (#524)
         """
         user_choice = self.organization_type
         excluded = [

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -568,7 +568,7 @@ class DomainApplication(TimeStampedModel):
         excluded = [
             DomainApplication.OrganizationChoices.FEDERAL,
             DomainApplication.OrganizationChoices.INTERSTATE,
-            DomainApplication.OrganizationChoices.SCHOOL_DISTRICT
+            DomainApplication.OrganizationChoices.SCHOOL_DISTRICT,
         ]
         return bool(user_choice and user_choice not in excluded)
 

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -567,6 +567,7 @@ class DomainApplication(TimeStampedModel):
         excluded = [
             DomainApplication.OrganizationChoices.FEDERAL,
             DomainApplication.OrganizationChoices.INTERSTATE,
+            DomainApplication.OrganizationChoices.SCHOOL_DISTRICT
         ]
         return bool(user_choice and user_choice not in excluded)
 


### PR DESCRIPTION
# This fixes #524!  #

## 🗣 Description ##

The fix only require a line added to the excluded list

## 💭 Motivation and context ##

The school district doesn't require election office to be declared. So I have added the `DomainApplication.OrganizationChoices.SCHOOL_DISTRICT` to the excluded list. I have ran this locally and tested it. When selecting School District, it now jump to "Organization name and mailing address" and doesn't show "Election Office" as expected result. I also added a comment line explaining that school district is now part of excluded list along with Federal and Interstate.

Resolves and closes #524 