### PR TITLE
Run migrations during db reset

### DIFF
--- a/.github/workflows/reset-db.yaml
+++ b/.github/workflows/reset-db.yaml
@@ -40,6 +40,22 @@ jobs:
           cf_space: ${{ github.event.inputs.environment }}
           full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py flush --no-input' --name flush"
 
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      CF_USERNAME: CF_${{ github.event.inputs.environment }}_USERNAME
+      CF_PASSWORD: CF_${{ github.event.inputs.environment }}_PASSWORD
+    steps:
+      - name: Run Django migrations for ${{ github.event.inputs.environment }}
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets[env.CF_USERNAME] }}
+          cf_password: ${{ secrets[env.CF_PASSWORD] }}
+          cf_org: cisa-getgov-prototyping
+          cf_space: ${{ github.event.inputs.environment }}
+          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"
+
+
       - name: Load fake data for ${{ github.event.inputs.environment }}
         uses: 18f/cg-deploy-action@main
         with:

--- a/.github/workflows/reset-db.yaml
+++ b/.github/workflows/reset-db.yaml
@@ -40,12 +40,6 @@ jobs:
           cf_space: ${{ github.event.inputs.environment }}
           full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py flush --no-input' --name flush"
 
-  migrate:
-    runs-on: ubuntu-latest
-    env:
-      CF_USERNAME: CF_${{ github.event.inputs.environment }}_USERNAME
-      CF_PASSWORD: CF_${{ github.event.inputs.environment }}_PASSWORD
-    steps:
       - name: Run Django migrations for ${{ github.event.inputs.environment }}
         uses: 18f/cg-deploy-action@main
         with:
@@ -54,7 +48,6 @@ jobs:
           cf_org: cisa-getgov-prototyping
           cf_space: ${{ github.event.inputs.environment }}
           full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"
-
 
       - name: Load fake data for ${{ github.event.inputs.environment }}
         uses: 18f/cg-deploy-action@main


### PR DESCRIPTION
## 🗣 Description ##

Copies the code from migrate.yaml into the Github action to reset the database.

[Successful workflow run is here](https://github.com/cisagov/getgov/actions/runs/5136975703).

## 💭 Motivation and context ##

The reasoning is that in some cases a "normal" migration will fail because it introduces a non-nullable foreign key or some other situation in which Django is not guaranteed to be able to resolve the existing records to maintain database integrity.

In that case, a sandbox user may try reseting the database, which flushes all data and then (re-)loads fixtures.

This PR introduces a step between those two actions to run the migrations. In case the migrations are already up-to-date, this step is harmless. In case a sandbox user is trying to resolve the above situation, this extra step will prove helpful, as it will run the migrations at a point when there is no existing data to cause integrity conflicts.