### PR TITLE
Fix authorizing official link on domain overview

### DIFF
--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -17,7 +17,7 @@
     {% url 'todo' as url %}
     {% include "includes/summary_item.html" with title='Organization name and mailing address' value=domain.domain_info address='true' edit_link=url %}
 
-    {% url 'todo' as url %}
+    {% url 'domain-authorizing-official' pk=domain.id as url %}
     {% include "includes/summary_item.html" with title='Authorizing official' value=domain.domain_info.authorizing_official contact='true' edit_link=url %}
 
     {% url 'domain-your-contact-information' pk=domain.id as url %}


### PR DESCRIPTION
# Include "Edit" link for authorizing official on domain overview #

## 🗣 Description ##

The newly landed Domain overview has "Edit" links for each of the items. We just merged the "Authorizing Official" form, but didn't put the correct link on the domain overview page. This includes the correct link destination for the domain's authorizing official.

![Screenshot 2023-06-01 at 3 11 57 PM](https://github.com/cisagov/getgov/assets/443389/a446265a-72b7-428b-b692-7d0da3f2b459)

## 💭 Motivation and context ##

Should have been included as part of #519. 