### PR TITLE
Update styles on Domain overview page

### DIFF
--- a/src/registrar/templates/application_status.html
+++ b/src/registrar/templates/application_status.html
@@ -4,11 +4,11 @@
 {% load static url_helpers %}
 
 {% block content %}
-<main id="main-content" class="grid-container register-form-step">
+<main id="main-content" class="grid-container">
   <div class="grid-col desktop:grid-offset-2 desktop:grid-col-8">
     <h1>Domain request for {{ domainapplication.requested_domain.name }}</h1>
     <div
-        class="usa-summary-box dotgov-status-box margin-top-3" 
+        class="usa-summary-box dotgov-status-box margin-top-3 padding-left-2" 
         role="region"
         aria-labelledby="summary-box-key-information"
     >
@@ -38,11 +38,11 @@
 
   <div class="grid-col desktop:grid-offset-2 maxw-tablet">
     <h2 class="text-primary-darker"> Summary of your domain request </h2> 
-
-    {% include "includes/summary_item.html" with title='Type of organization' value=domainapplication.get_organization_type_display %}
+    {% with heading_level='h3' %}
+    {% include "includes/summary_item.html" with title='Type of organization' value=domainapplication.get_organization_type_display heading_level=heading_level %}
 
     {% if domainapplication.tribe_name %}
-      {% include "includes/summary_item.html" with title='Tribal government' value=domainapplication.tribe_name %}
+      {% include "includes/summary_item.html" with title='Tribal government' value=domainapplication.tribe_name heading_level=heading_level %}
 
       {% if domainapplication.federally_recognized_tribe %}
         <p>Federally-recognized tribe</p>
@@ -55,44 +55,46 @@
     {% endif %}
 
     {% if domainapplication.get_federal_type_display %}
-      {% include "includes/summary_item.html" with title='Federal government branch' value=domainapplication.get_federal_type_display %}
+      {% include "includes/summary_item.html" with title='Federal government branch' value=domainapplication.get_federal_type_display heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.is_election_board %}
-      {% include "includes/summary_item.html" with title='Election office' value=domainapplication.is_election_board %}
+      {% include "includes/summary_item.html" with title='Election office' value=domainapplication.is_election_board heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.organization_name %}
-      {% include "includes/summary_item.html" with title='Organization name and mailing address' value=domainapplication  address='true' %}
+      {% include "includes/summary_item.html" with title='Organization name and mailing address' value=domainapplication  address='true' heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.type_of_work %}
-      {% include "includes/summary_item.html" with title='Type of work' value=domainapplication.type_of_work %}
+      {% include "includes/summary_item.html" with title='Type of work' value=domainapplication.type_of_work heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.more_organization_information %}
-      {% include "includes/summary_item.html" with title='More information about your organization' value=domainapplication.more_organization_information %}
+      {% include "includes/summary_item.html" with title='More information about your organization' value=domainapplication.more_organization_information heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.authorizing_official %}
-      {% include "includes/summary_item.html" with title='Authorizing official' value=domainapplication.authorizing_official contact='true' %}
+      {% include "includes/summary_item.html" with title='Authorizing official' value=domainapplication.authorizing_official contact='true' heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.current_websites.all %}
-      {% include "includes/summary_item.html" with title='Current website for your organization' value=domainapplication.current_websites.all list='true' %}
+      {% include "includes/summary_item.html" with title='Current website for your organization' value=domainapplication.current_websites.all list='true' heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.purpose %}
-      {% include "includes/summary_item.html" with title='Purpose of your domain' value=domainapplication.purpose %}
+      {% include "includes/summary_item.html" with title='Purpose of your domain' value=domainapplication.purpose heading_level=heading_level %}
     {% endif %}
 
     {% if domainapplication.submitter %}
-      {% include "includes/summary_item.html" with title='Your contact information' value=domainapplication.submitter contact='true'%}
+      {% include "includes/summary_item.html" with title='Your contact information' value=domainapplication.submitter contact='true' heading_level=heading_level %}
     {% endif %}
 
-    {% include "includes/summary_item.html" with title='Other employees from your organization' value=domainapplication.other_contacts.all contact='true' list='true' %}
-    {% include "includes/summary_item.html" with title='Anything else we should know' value=domainapplication.anything_else|default:"No" %}
+    {% include "includes/summary_item.html" with title='Other employees from your organization' value=domainapplication.other_contacts.all contact='true' list='true' heading_level=heading_level %}
 
+    {% include "includes/summary_item.html" with title='Anything else we should know' value=domainapplication.anything_else|default:"No" heading_level=heading_level %}
+
+  {% endwith %}
   </div>
 
 </main>

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -12,7 +12,8 @@
       class="summary-item__title
              font-sans-md
              text-primary-dark text-semibold
-             margin-top-0 margin-bottom-05"
+             margin-top-0 margin-bottom-05
+             padding-right-1"
       >
         {{ title }}
     {% if heading_level %}

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -4,60 +4,73 @@
   <hr class="" aria-hidden="true" />
   <div class="display-flex flex-justify">
     <div>
-    <h2 class="summary-item__title
-              font-sans-md
-              text-primary-dark text-semibold
-              margin-top-0 margin-bottom-05"
-    >
-    {{ title }}
-    </h2>
-    {% if address %}
-      {% include "includes/organization_address.html" with organization=value %}
-    {% elif contact %}
-      {% if list %}
-        {% if value|length == 1 %}
-          {% include "includes/contact.html" with contact=value|first %}
+    {% if heading_level %}
+      <{{ heading_level }}
+    {% else %} 
+      <h2
+    {% endif %} 
+      class="summary-item__title
+             font-sans-md
+             text-primary-dark text-semibold
+             margin-top-0 margin-bottom-05"
+      >
+        {{ title }}
+    {% if heading_level %}
+      </{{ heading_level }}>
+    {% else %} 
+      </h2>
+    {% endif %}
+      {% if address %}
+        {% include "includes/organization_address.html" with organization=value %}
+      {% elif contact %}
+        {% if list %}
+          {% if value|length == 1 %}
+            {% include "includes/contact.html" with contact=value|first %}
+          {% else %}
+            <ul class="usa-list usa-list--unstyled margin-top-0">
+              {% for item in value %}
+              <li>
+                <p class="text-semibold margin-top-1 margin-bottom-0">
+                  Contact {{forloop.counter}}
+                </p>
+                {% include "includes/contact.html" with contact=item %}</li>
+              {% empty %}
+               <li>None</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
         {% else %}
-          <ul class="usa-list usa-list--unstyled margin-top-0">
+          {% include "includes/contact.html" with contact=value %}
+        {% endif %}
+      {% elif list %}
+        {% if value|length == 1 %}
+            {% if users %}
+              <p class="margin-top-0">{{ value.0.user.email }} </p>
+            {% else %}
+              <p class="margin-top-0">{{ value | first }} </p>
+            {% endif %}
+        {% else %}
+          <ul class="usa-list margin-top-0">
             {% for item in value %}
-            <li>
-              <p class="text-semibold margin-top-1 margin-bottom-0">
-                Contact {{forloop.counter}}
-              </p>
-              {% include "includes/contact.html" with contact=item %}</li>
+            {% if users %}
+              <li>{{ item.user.email }}</li>
+            {% else %}
+              <li>{{ item }}</li>
+            {% endif %}
             {% empty %}
              <li>None</li>
             {% endfor %}
           </ul>
         {% endif %}
       {% else %}
-        {% include "includes/contact.html" with contact=value %}
+      <p class="margin-top-0 margin-bottom-0">
+        {% if value %}
+          {{ value }}
+        {% else %}
+          None
+        {% endif %}
+      </p>
       {% endif %}
-    {% elif list %}
-      {% if value|length == 1 %}
-          {% if users %}
-            <p class="margin-top-0">{{ value.0.user.email }} </p>
-          {% else %}
-            <p class="margin-top-0">{{ value | first }} </p>
-          {% endif %}
-      {% else %}
-        <ul class="usa-list margin-top-0">
-          {% for item in value %}
-          {% if users %}
-            <li>{{ item.user.email }}</li>
-          {% else %}
-            <li>{{ item }}</li>
-          {% endif %}
-          {% empty %}
-           <li>None</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    {% else %}
-    <p class="margin-top-0">
-      {{ value }}
-    </p>
-    {% endif %}
     </div>
 
     {% if edit_link %}

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -78,7 +78,7 @@
       <div class="text-right">
       <a
           href="{{ edit_link }}"
-          class="usa-link"
+          class="usa-link font-sans-sm"
       >
         Edit<span class="sr-only"> {{ title }}</span>
       </a>

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -27,7 +27,7 @@
               {% include "includes/contact.html" with contact=item %}</li>
             {% empty %}
              <li>None</li>
-            {% endfor %}</ul></p>
+            {% endfor %}
           </ul>
         {% endif %}
       {% else %}
@@ -50,7 +50,7 @@
           {% endif %}
           {% empty %}
            <li>None</li>
-          {% endfor %}</ul></p>
+          {% endfor %}
         </ul>
       {% endif %}
     {% else %}

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -2,66 +2,72 @@
 
 <section class="summary-item margin-top-3">
   <hr class="" aria-hidden="true" />
-  <h2 class="summary-item__title
-            text-primary-dark text-semibold
-            margin-top-0 margin-bottom-05"
-  >
-  {{ title }}
-  </h2>
-  {% if address %}
-    {% include "includes/organization_address.html" with organization=value %}
-  {% elif contact %}
-    {% if list %}
-      {% if value|length == 1 %}
-        {% include "includes/contact.html" with contact=value|first %}
+  <div class="display-flex flex-justify">
+    <div>
+    <h2 class="summary-item__title
+              text-primary-dark text-semibold
+              margin-top-0 margin-bottom-05"
+    >
+    {{ title }}
+    </h2>
+    {% if address %}
+      {% include "includes/organization_address.html" with organization=value %}
+    {% elif contact %}
+      {% if list %}
+        {% if value|length == 1 %}
+          {% include "includes/contact.html" with contact=value|first %}
+        {% else %}
+          <ul class="usa-list usa-list--unstyled margin-top-0">
+            {% for item in value %}
+            <li>
+              <p class="text-semibold margin-top-1 margin-bottom-0">
+                Contact {{forloop.counter}}
+              </p>
+              {% include "includes/contact.html" with contact=item %}</li>
+            {% empty %}
+             <li>None</li>
+            {% endfor %}</ul></p>
+          </ul>
+        {% endif %}
       {% else %}
-        <ul class="usa-list usa-list--unstyled margin-top-0">
+        {% include "includes/contact.html" with contact=value %}
+      {% endif %}
+    {% elif list %}
+      {% if value|length == 1 %}
+          {% if users %}
+            <p class="margin-top-0">{{ value.0.user.email }} </p>
+          {% else %}
+            <p class="margin-top-0">{{ value | first }} </p>
+          {% endif %}
+      {% else %}
+        <ul class="usa-list margin-top-0">
           {% for item in value %}
-          <li>
-            <p class="text-semibold margin-top-1 margin-bottom-0">
-              Contact {{forloop.counter}}
-            </p>
-            {% include "includes/contact.html" with contact=item %}</li>
+          {% if users %}
+            <li>{{ item.user.email }}</li>
+          {% else %}
+            <li>{{ item }}</li>
+          {% endif %}
           {% empty %}
            <li>None</li>
           {% endfor %}</ul></p>
         </ul>
       {% endif %}
     {% else %}
-      {% include "includes/contact.html" with contact=value %}
+    <p class="margin-top-0">
+      {{ value }}
+    </p>
     {% endif %}
-  {% elif list %}
-    {% if value|length == 1 %}
-        {% if users %}
-          <p class="margin-top-0">{{ value.0.user.email }} </p>
-        {% else %}
-          <p class="margin-top-0">{{ value | first }} </p>
-        {% endif %}
-    {% else %}
-      <ul class="usa-list margin-top-0">
-        {% for item in value %}
-        {% if users %}
-          <li>{{ item.user.email }}</li>
-        {% else %}
-          <li>{{ item }}</li>
-        {% endif %}
-        {% empty %}
-         <li>None</li>
-        {% endfor %}</ul></p>
-      </ul>
-    {% endif %}
-  {% else %}
-  <p class="margin-top-0">
-    {{ value }}
-  </p>
-  {% endif %}
+    </div>
 
     {% if edit_link %}
-    <a
-        href="{{ edit_link }}"
-    >
-      Edit<span class="sr-only"> {{ title }}</span>
-    </a>
+      <div class="text-right">
+      <a
+          href="{{ edit_link }}"
+          class="usa-link"
+      >
+        Edit<span class="sr-only"> {{ title }}</span>
+      </a>
+      </div>
     {% endif %}
-
+ </div>
 </section>

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -5,6 +5,7 @@
   <div class="display-flex flex-justify">
     <div>
     <h2 class="summary-item__title
+              font-sans-md
               text-primary-dark text-semibold
               margin-top-0 margin-bottom-05"
     >


### PR DESCRIPTION
## 🗣 Description ##

This PR follows up on the comments in #631 with a number of style updates. It moves the edit button back up to the right, and reduces the size of the heading for each section. Additionally, because the `summary-item` include is used on both the "Domain overview" page and the "Domain request summary" page, but requires different heading levels, this PR adds a `heading_level` option to the include. Thanks to @neilmb for advice on setting that up!

<img width="1445" alt="Updates to the  summary item include on the Domain overview page" src="https://github.com/cisagov/getgov/assets/52677065/ce19b880-7571-4b7e-bd2e-7a3962ffb6bf">

<img width="1445" alt="Updates to the  summary item include on the Submitted request page" src="https://github.com/cisagov/getgov/assets/52677065/ed1c42c9-f403-406f-8e96-4cf86724394e">

