### PR TITLE
Add content team members to fixtures

### DIFF
--- a/src/registrar/fixtures.py
+++ b/src/registrar/fixtures.py
@@ -59,6 +59,21 @@ class UserFixture:
             "first_name": "Alysia",
             "last_name": "Broddrick",
         },
+        {
+            "username": "55a3bc26-cd1d-4a5c-a8c0-7e1f561ef7f4",
+            "first_name": "Michelle",
+            "last_name": "Rago",
+        },
+        {
+            "username": "8f8e7293-17f7-4716-889b-1990241cbd39",
+            "first_name": "Katherine",
+            "last_name": "Osos",
+        },
+        {
+            "username": "70488e0a-e937-4894-a28c-16f5949effd4",
+            "first_name": "Gaby",
+            "last_name": "DiSarli",
+        },
     ]
 
     @classmethod


### PR DESCRIPTION
# Add more people to our list of users who get test data automatically #

## 🗣 Description ##

Our migration jobs load up test data for a set of users specified in `registrar/fixtures.py` according to their UUIDs. Users who are listed there will get a full set of domain applications loaded up in different statuses and a single approved domain. For testing and content development, we want to load up this test data for members of our content design team. This PR adds @Katherine-Osos @gabydisarli and @michelle-rago to that list. 

## 💭 Motivation and context ##

Hopefully improves velocity for content team members to be able to test domain applications and domain management.