### PR TITLE
Get environment variable from a better location

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -48,6 +48,7 @@ env_db_url = env.dj_db_url("DATABASE_URL")
 env_debug = env.bool("DJANGO_DEBUG", default=False)
 env_log_level = env.str("DJANGO_LOG_LEVEL", "DEBUG")
 env_base_url = env.str("DJANGO_BASE_URL")
+env_getgov_public_site_url = env.str("GETGOV_PUBLIC_SITE_URL", "")
 
 secret_login_key = b64decode(secret("DJANGO_SECRET_LOGIN_KEY", ""))
 secret_key = secret("DJANGO_SECRET_KEY")
@@ -61,8 +62,6 @@ secret_registry_cert = b64decode(secret("REGISTRY_CERT", ""))
 secret_registry_key = b64decode(secret("REGISTRY_KEY", ""))
 secret_registry_key_passphrase = secret("REGISTRY_KEY_PASSPHRASE", "")
 secret_registry_hostname = secret("REGISTRY_HOSTNAME")
-
-secret_getgov_public_site_url = secret("GETGOV_PUBLIC_SITE_URL", "")
 
 # region: Basic Django Config-----------------------------------------------###
 
@@ -509,7 +508,7 @@ STATIC_URL = "public/"
 
 # Base URL of our separate static public website. Used by the
 # {% public_site_url subdir/path %} template tag
-GETGOV_PUBLIC_SITE_URL = secret_getgov_public_site_url
+GETGOV_PUBLIC_SITE_URL = env_getgov_public_site_url
 
 # endregion
 # region: Registry----------------------------------------------------------###


### PR DESCRIPTION
# Fix GETGOV_PUBLIC_SITE_URL #

## 🗣 Description ##

I was getting the value of the `GETGOV_PUBLIC_SITE_URL` environment variable in the wrong way in `registrar/config/settings.py`. This should fix the `{% public_site_url ... %}` helper in our sandbox environments.

## 💭 Motivation and context ##

Fixes a bug that prevents `public_site_url` from working right.