### PR TITLE
Fix broken issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug
 description: Report a bug or problem with the application
-title: ""
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,6 +1,5 @@
 name: Story
 description: Capture actionable sprint work
-title: ""
 labels: ["story"]
 
 body:


### PR DESCRIPTION
## 🗣 Description ##

#694 broke our [bug](https://github.com/cisagov/getgov/blob/main/.github/ISSUE_TEMPLATE/bug.yml) and [story](https://github.com/cisagov/getgov/blob/main/.github/ISSUE_TEMPLATE/story.yml) templates due to the title attribute not being allowed to be empty. Instead it should be omitted