### PR TITLE
Using State Transition for Withdraw

### DIFF
--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -541,6 +541,10 @@ class DomainApplication(TimeStampedModel):
             user=self.creator, domain=created_domain, role=UserDomainRole.Roles.ADMIN
         )
 
+    @transition(field="status", source=[SUBMITTED, INVESTIGATING], target=WITHDRAWN)
+    def withdraw(self):
+        """Withdraw an application that has been submitted."""
+
     # ## Form policies ###
     #
     # These methods control what questions need to be answered by applicants

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -502,6 +502,6 @@ class ApplicationWithdrawn(DomainApplicationPermissionView):
         to withdraw and send back to homepage.
         """
         application = DomainApplication.objects.get(id=self.kwargs["pk"])
-        application.status = "withdrawn"
+        application.withdraw()
         application.save()
         return HttpResponseRedirect(reverse("home"))


### PR DESCRIPTION
# Withdraw State Transition added #

## 🗣 Description ##

* Added withdraw transition
* Edited the withdraw process to use state transition instead of update the field manually.
* Ran Test to ensure nothing else break

## 💭 Motivation and context ##
This will change the way withdraw process in the backend. Before it was set as update field, but we have seen some places where approved were be able to withdraw. Using state transition in place for withdraw will protect it from making an accidental or mess up when withdrawing an application that is not in "submitted/review" state
Resolves and Closes #690 