### PR TITLE
no input on colllectstatic for stable deploy

### DIFF
--- a/.github/workflows/deploy-stable.yaml
+++ b/.github/workflows/deploy-stable.yaml
@@ -28,7 +28,7 @@ jobs:
           docker compose run node npx gulp compile 
       - name: Collect static assets 
         working-directory: ./src
-        run: docker compose run app python manage.py collectstatic
+        run: docker compose run app python manage.py collectstatic --no-input
       - name: Deploy to cloud.gov sandbox
         uses: 18f/cg-deploy-action@main
         env:


### PR DESCRIPTION
Changing this to match what happens in the sandbox script. 