### PR TITLE
Fix README top-level header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Get (your very own) .gov
-========================
 
 Welcome to the repo for a WIP brand new registrar for .gov domains. Get.gov intends to serve all government entities in the United States looking for a .gov domain to use publicly (for a website, for an email address, etc.). Here you can find the code for the registrar and other artifacts about our product strategy and research. 
 


### PR DESCRIPTION
This is unneeded since the heading is already prefixed by `#`
