### PR TITLE
Implement side effects when domain gets approved from django admin

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -99,7 +99,7 @@ class DomainApplicationAdmin(AuditedAdmin):
                     # transition condition is violated, so we call it on the
                     # original object which has the right status value, and pass
                     # the updated object which contains the up-to-date data
-                    # for the side effects (like an email send). Same 
+                    # for the side effects (like an email send). Same
                     # comment applies to original_obj method calls below.
                     original_obj.submit(updated_domain_application=obj)
                 elif obj.status == models.DomainApplication.INVESTIGATING:

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -90,16 +90,36 @@ class DomainApplicationAdmin(AuditedAdmin):
             # Get the original application from the database
             original_obj = models.DomainApplication.objects.get(pk=obj.pk)
 
-            if (
-                obj.status != original_obj.status
-                and obj.status == models.DomainApplication.INVESTIGATING
-            ):
-                # This is a transition annotated method in model which will throw an
-                # error if the condition is violated. To make this work, we need to
-                # call it on the original object which has the right status value,
-                # but pass the current object which contains the up-to-date data
-                # for the email.
-                original_obj.in_review(obj)
+            if obj.status != original_obj.status:
+                if obj.status == models.DomainApplication.STARTED:
+                    # No conditions
+                    pass
+                if obj.status == models.DomainApplication.SUBMITTED:
+                    # This is an fsm in model which will throw an error if the
+                    # transition condition is violated, so we call it on the
+                    # original object which has the right status value, and pass
+                    # the updated object which contains the up-to-date data
+                    # for the side effects (like an email send).
+                    original_obj.submit(updated_domain_application=obj)
+                if obj.status == models.DomainApplication.INVESTIGATING:
+                    # This is an fsm in model which will throw an error if the
+                    # transition condition is violated, so we call it on the
+                    # original object which has the right status value, and pass
+                    # the updated object which contains the up-to-date data
+                    # for the side effects (like an email send).
+                    original_obj.in_review(updated_domain_application=obj)
+                if obj.status == models.DomainApplication.APPROVED:
+                    # This is an fsm in model which will throw an error if the
+                    # transition condition is violated, so we call it on the
+                    # original object which has the right status value, and pass
+                    # the updated object which contains the up-to-date data
+                    # for the side effects (like an email send).
+                    original_obj.approve(updated_domain_application=obj)
+                if obj.status == models.DomainApplication.WITHDRAWN:
+                    # This is a transition annotated method in model which will throw an
+                    # error if the condition is violated. To make this work, we need to
+                    # call it on the original object which has the right status value.
+                    original_obj.withdraw()
 
         super().save_model(request, obj, form, change)
 

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -108,6 +108,8 @@ class DomainApplicationAdmin(AuditedAdmin):
                     original_obj.approve(updated_domain_application=obj)
                 elif obj.status == models.DomainApplication.WITHDRAWN:
                     original_obj.withdraw()
+                else:
+                    logger.warning("Unknown status selected in django admin")
 
         super().save_model(request, obj, form, change)
 

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -94,31 +94,19 @@ class DomainApplicationAdmin(AuditedAdmin):
                 if obj.status == models.DomainApplication.STARTED:
                     # No conditions
                     pass
-                if obj.status == models.DomainApplication.SUBMITTED:
+                elif obj.status == models.DomainApplication.SUBMITTED:
                     # This is an fsm in model which will throw an error if the
                     # transition condition is violated, so we call it on the
                     # original object which has the right status value, and pass
                     # the updated object which contains the up-to-date data
-                    # for the side effects (like an email send).
+                    # for the side effects (like an email send). Same 
+                    # comment applies to original_obj method calls below.
                     original_obj.submit(updated_domain_application=obj)
-                if obj.status == models.DomainApplication.INVESTIGATING:
-                    # This is an fsm in model which will throw an error if the
-                    # transition condition is violated, so we call it on the
-                    # original object which has the right status value, and pass
-                    # the updated object which contains the up-to-date data
-                    # for the side effects (like an email send).
+                elif obj.status == models.DomainApplication.INVESTIGATING:
                     original_obj.in_review(updated_domain_application=obj)
-                if obj.status == models.DomainApplication.APPROVED:
-                    # This is an fsm in model which will throw an error if the
-                    # transition condition is violated, so we call it on the
-                    # original object which has the right status value, and pass
-                    # the updated object which contains the up-to-date data
-                    # for the side effects (like an email send).
+                elif obj.status == models.DomainApplication.APPROVED:
                     original_obj.approve(updated_domain_application=obj)
-                if obj.status == models.DomainApplication.WITHDRAWN:
-                    # This is a transition annotated method in model which will throw an
-                    # error if the condition is violated. To make this work, we need to
-                    # call it on the original object which has the right status value.
+                elif obj.status == models.DomainApplication.WITHDRAWN:
                     original_obj.withdraw()
 
         super().save_model(request, obj, form, change)

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -500,9 +500,9 @@ class DomainApplication(TimeStampedModel):
     @transition(field="status", source=[STARTED, WITHDRAWN], target=SUBMITTED)
     def submit(self, updated_domain_application=None):
         """Submit an application that is started.
-        
+
         As a side effect, an email notification is sent.
-        
+
         This method is called in admin.py on the original application
         which has the correct status value, but is passed the changed
         application which has the up-to-date data that we'll use
@@ -543,7 +543,7 @@ class DomainApplication(TimeStampedModel):
         """Investigate an application that has been submitted.
 
         As a side effect, an email notification is sent.
-        
+
         This method is called in admin.py on the original application
         which has the correct status value, but is passed the changed
         application which has the up-to-date data that we'll use
@@ -563,7 +563,7 @@ class DomainApplication(TimeStampedModel):
         object for the approved Domain and makes the user who created the
         application into an admin on that domain. It also triggers an email
         notification.
-        
+
         This method is called in admin.py on the original application
         which has the correct status value, but is passed the changed
         application which has the up-to-date data that we'll use

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -471,59 +471,34 @@ class DomainApplication(TimeStampedModel):
         except Exception:
             return ""
 
-    def _send_confirmation_email(self):
-        """Send a confirmation email that this application was submitted.
+    def _send_status_update_email(
+        self, new_status, email_template, email_template_subject
+    ):
+        """Send a atatus update email to the submitter.
 
         The email goes to the email address that the submitter gave as their
         contact information. If there is not submitter information, then do
         nothing.
         """
+
         if self.submitter is None or self.submitter.email is None:
             logger.warning(
-                "Cannot send confirmation email, no submitter email address."
+                f"Cannot send {new_status} email, no submitter email address."
             )
             return
         try:
             send_templated_email(
-                "emails/submission_confirmation.txt",
-                "emails/submission_confirmation_subject.txt",
+                email_template,
+                email_template_subject,
                 self.submitter.email,
                 context={"application": self},
             )
-            logger.info(
-                f"Submission confirmation email sent to: {self.submitter.email}"
-            )
+            logger.info(f"The {new_status} email sent to: {self.submitter.email}")
         except EmailSendingError:
             logger.warning("Failed to send confirmation email", exc_info=True)
 
-    def _send_in_review_email(self):
-        """Send an email that this application is now in review.
-
-        The email goes to the email address that the submitter gave as their
-        contact information. If there is not submitter information, then do
-        nothing.
-        """
-        if self.submitter is None or self.submitter.email is None:
-            logger.warning(
-                "Cannot send status change (in review) email,"
-                "no submitter email address."
-            )
-            return
-        try:
-            send_templated_email(
-                "emails/status_change_in_review.txt",
-                "emails/status_change_in_review_subject.txt",
-                self.submitter.email,
-                context={"application": self},
-            )
-            logging.info(f"In review email sent to: {self.submitter.email}")
-        except EmailSendingError:
-            logger.warning(
-                "Failed to send status change (in review) email", exc_info=True
-            )
-
     @transition(field="status", source=[STARTED, WITHDRAWN], target=SUBMITTED)
-    def submit(self):
+    def submit(self, updated_domain_application=None):
         """Submit an application that is started."""
 
         # check our conditions here inside the `submit` method so that we
@@ -542,10 +517,40 @@ class DomainApplication(TimeStampedModel):
 
         # When an application is submitted, we need to send a confirmation email
         # This is a side-effect of the state transition
-        self._send_confirmation_email()
+        if updated_domain_application is not None:
+            # A DomainApplication is being passed to this method (ie from admin)
+            updated_domain_application._send_status_update_email(
+                "submission confirmation",
+                "emails/submission_confirmation.txt",
+                "emails/submission_confirmation_subject.txt",
+            )
+        else:
+            # views/application.py
+            self._send_status_update_email(
+                "submission confirmation",
+                "emails/submission_confirmation.txt",
+                "emails/submission_confirmation_subject.txt",
+            )
+
+    @transition(field="status", source=SUBMITTED, target=INVESTIGATING)
+    def in_review(self, updated_domain_application):
+        """Investigate an application that has been submitted.
+
+        This method is called in admin.py on the original application
+        which has the correct status value, but is passed the changed
+        application which has the up-to-date data that we'll use
+        in the email."""
+
+        # When an application is moved to in review, we need to send a
+        # confirmation email. This is a side-effect of the state transition
+        updated_domain_application._send_status_update_email(
+            "application in review",
+            "emails/status_change_in_review.txt",
+            "emails/status_change_in_review_subject.txt",
+        )
 
     @transition(field="status", source=[SUBMITTED, INVESTIGATING], target=APPROVED)
-    def approve(self):
+    def approve(self, updated_domain_application=None):
         """Approve an application that has been submitted.
 
         This has substantial side-effects because it creates another database
@@ -570,18 +575,21 @@ class DomainApplication(TimeStampedModel):
             user=self.creator, domain=created_domain, role=UserDomainRole.Roles.ADMIN
         )
 
-    @transition(field="status", source=SUBMITTED, target=INVESTIGATING)
-    def in_review(self, updated_domain_application):
-        """Investigate an application that has been submitted.
-
-        This method is called in admin.py on the original application
-        which has the correct status value, but is passed the changed
-        application which has the up-to-date data that we'll use
-        in the email."""
-
         # When an application is moved to in review, we need to send a
         # confirmation email. This is a side-effect of the state transition
-        updated_domain_application._send_in_review_email()
+        if updated_domain_application is not None:
+            # A DomainApplication is being passed to this method (ie from admin)
+            updated_domain_application._send_status_update_email(
+                "application approved",
+                "emails/status_change_approved.txt",
+                "emails/status_change_approved_subject.txt",
+            )
+        else:
+            self._send_status_update_email(
+                "application approved",
+                "emails/status_change_approved.txt",
+                "emails/status_change_approved.txt",
+            )
 
     @transition(field="status", source=[SUBMITTED, INVESTIGATING], target=WITHDRAWN)
     def withdraw(self):

--- a/src/registrar/templates/emails/status_change_approved.txt
+++ b/src/registrar/templates/emails/status_change_approved.txt
@@ -1,0 +1,40 @@
+{% autoescape off %}{# In a text file, we don't want to have HTML entities escaped #}
+Hi {{ application.submitter.first_name }}.
+
+Congratulations! Your .gov domain request has been approved.
+
+DOMAIN REQUESTED: {{ application.requested_domain.name }}
+REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST #: {{ application.id }}
+STATUS: In review
+
+Now that your .gov domain has been approved, there are a few more things to do before your domain can be used. 
+
+
+YOU MUST ADD DOMAIN NAME SERVER INFORMATION
+
+Before your .gov domain can be used, you have to connect it to your Domain Name System (DNS) hosting service. At this time, we don’t provide DNS hosting services.
+Go to the domain management page to add your domain name server information <https://registrar.get.gov/domain/{{ application.id }}/nameservers>.
+
+Get help with adding your domain name server information <https://get.gov/help/domain-management/#manage-dns-information-for-your-domain>.
+
+
+ADD DOMAIN MANAGERS, SECURITY EMAIL
+
+We strongly recommend that you add other points of contact who will help manage your domain. We also recommend that you provide a security email. This email will allow the public to report security issues on your domain. Security emails are made public. 
+
+Go to the domain management page to add domain contacts <https://registrar.get.gov/domain/{{ application.id }}/your-contact-information> and a security email <https://registrar.get.gov/domain/{{ application.id }}/security-email>. 
+
+Get help with managing your .gov domain <https://get.gov/help/domain-management/>.
+
+
+THANK YOU
+
+.Gov helps the public identify official, trusted information. Thank you for using a .gov domain.
+
+----------------------------------------------------------------
+
+The .gov team
+Contact us: <https://get.gov/contact/>
+Visit <https://get.gov>
+{% endautoescape %}

--- a/src/registrar/templates/emails/status_change_approved_subject.txt
+++ b/src/registrar/templates/emails/status_change_approved_subject.txt
@@ -1,0 +1,1 @@
+Your .gov domain request is approved

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -159,5 +159,6 @@ class TestDomainApplicationAdmin(TestCase):
         mock_client_instance.send_email.assert_called_once()
 
         # Cleanup
-        DomainInformation.objects.get(id=application.pk).delete()
+        if DomainInformation.objects.get(id=application.pk) is not None:
+            DomainInformation.objects.get(id=application.pk).delete()
         application.delete()

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from registrar.admin import DomainApplicationAdmin
-from registrar.models import DomainApplication, User
+from registrar.models import DomainApplication, DomainInformation, User
 from .common import completed_application
 
 from django.conf import settings
@@ -15,7 +15,56 @@ class TestDomainApplicationAdmin(TestCase):
         self.factory = RequestFactory()
 
     @boto3_mocking.patching
-    def test_save_model_sends_email_on_property_change(self):
+    def test_save_model_sends_submitted_email(self):
+        # make sure there is no user with this email
+        EMAIL = "mayor@igorville.gov"
+        User.objects.filter(email=EMAIL).delete()
+
+        mock_client = MagicMock()
+        mock_client_instance = mock_client.return_value
+
+        with boto3_mocking.clients.handler_for("sesv2", mock_client):
+            # Create a sample application
+            application = completed_application()
+
+            # Create a mock request
+            request = self.factory.post(
+                "/admin/registrar/domainapplication/{}/change/".format(application.pk)
+            )
+
+            # Create an instance of the model admin
+            model_admin = DomainApplicationAdmin(DomainApplication, self.site)
+
+            # Modify the application's property
+            application.status = DomainApplication.SUBMITTED
+
+            # Use the model admin's save_model method
+            model_admin.save_model(request, application, form=None, change=True)
+
+        # Access the arguments passed to send_email
+        call_args = mock_client_instance.send_email.call_args
+        args, kwargs = call_args
+
+        # Retrieve the email details from the arguments
+        from_email = kwargs.get("FromEmailAddress")
+        to_email = kwargs["Destination"]["ToAddresses"][0]
+        email_content = kwargs["Content"]
+        email_body = email_content["Simple"]["Body"]["Text"]["Data"]
+
+        # Assert or perform other checks on the email details
+        expected_string = "We received your .gov domain request."
+        self.assertEqual(from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(to_email, EMAIL)
+        self.assertIn(expected_string, email_body)
+
+        # Perform assertions on the mock call itself
+        mock_client_instance.send_email.assert_called_once()
+
+        # Cleanup
+        application.delete()
+
+    @boto3_mocking.patching
+    def test_save_model_sends_in_review_email(self):
         # make sure there is no user with this email
         EMAIL = "mayor@igorville.gov"
         User.objects.filter(email=EMAIL).delete()
@@ -52,7 +101,7 @@ class TestDomainApplicationAdmin(TestCase):
         email_body = email_content["Simple"]["Body"]["Text"]["Data"]
 
         # Assert or perform other checks on the email details
-        expected_string = "Your .gov domain request is being reviewed"
+        expected_string = "Your .gov domain request is being reviewed."
         self.assertEqual(from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(to_email, EMAIL)
         self.assertIn(expected_string, email_body)
@@ -61,4 +110,54 @@ class TestDomainApplicationAdmin(TestCase):
         mock_client_instance.send_email.assert_called_once()
 
         # Cleanup
+        application.delete()
+
+    @boto3_mocking.patching
+    def test_save_model_sends_approved_email(self):
+        # make sure there is no user with this email
+        EMAIL = "mayor@igorville.gov"
+        User.objects.filter(email=EMAIL).delete()
+
+        mock_client = MagicMock()
+        mock_client_instance = mock_client.return_value
+
+        with boto3_mocking.clients.handler_for("sesv2", mock_client):
+            # Create a sample application
+            application = completed_application(status=DomainApplication.INVESTIGATING)
+
+            # Create a mock request
+            request = self.factory.post(
+                "/admin/registrar/domainapplication/{}/change/".format(application.pk)
+            )
+
+            # Create an instance of the model admin
+            model_admin = DomainApplicationAdmin(DomainApplication, self.site)
+
+            # Modify the application's property
+            application.status = DomainApplication.APPROVED
+
+            # Use the model admin's save_model method
+            model_admin.save_model(request, application, form=None, change=True)
+
+        # Access the arguments passed to send_email
+        call_args = mock_client_instance.send_email.call_args
+        args, kwargs = call_args
+
+        # Retrieve the email details from the arguments
+        from_email = kwargs.get("FromEmailAddress")
+        to_email = kwargs["Destination"]["ToAddresses"][0]
+        email_content = kwargs["Content"]
+        email_body = email_content["Simple"]["Body"]["Text"]["Data"]
+
+        # Assert or perform other checks on the email details
+        expected_string = "Congratulations! Your .gov domain request has been approved."
+        self.assertEqual(from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(to_email, EMAIL)
+        self.assertIn(expected_string, email_body)
+
+        # Perform assertions on the mock call itself
+        mock_client_instance.send_email.assert_called_once()
+
+        # Cleanup
+        DomainInformation.objects.get(id=application.pk).delete()
         application.delete()

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -14,7 +14,8 @@ from registrar.models import (
 )
 
 import boto3_mocking  # type: ignore
-from .common import MockSESClient, less_console_noise
+from .common import MockSESClient, less_console_noise, completed_application
+from django_fsm import TransitionNotAllowed
 
 boto3_mocking.clients.register_handler("sesv2", MockSESClient)
 
@@ -133,6 +134,123 @@ class TestDomainApplication(TestCase):
             ),
             0,
         )
+
+    def test_transition_not_allowed_submitted_submitted(self):
+        """Create an application with status submitted and call submit
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.SUBMITTED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.submit()
+
+    def test_transition_not_allowed_investigating_submitted(self):
+        """Create an application with status investigating and call submit
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.INVESTIGATING)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.submit()
+
+    def test_transition_not_allowed_approved_submitted(self):
+        """Create an application with status approved and call submit
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.APPROVED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.submit()
+
+    def test_transition_not_allowed_started_investigating(self):
+        """Create an application with status started and call in_review
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.STARTED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.in_review()
+
+    def test_transition_not_allowed_investigating_investigating(self):
+        """Create an application with status investigating and call in_review
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.INVESTIGATING)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.in_review()
+
+    def test_transition_not_allowed_approved_investigating(self):
+        """Create an application with status approved and call in_review
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.APPROVED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.in_review()
+
+    def test_transition_not_allowed_withdrawn_investigating(self):
+        """Create an application with status withdrawn and call in_review
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.WITHDRAWN)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.in_review()
+
+    def test_transition_not_allowed_started_approved(self):
+        """Create an application with status started and call approve
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.STARTED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.approve()
+
+    def test_transition_not_allowed_approved_approved(self):
+        """Create an application with status approved and call approve
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.APPROVED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.approve()
+
+    def test_transition_not_allowed_withdrawn_approved(self):
+        """Create an application with status withdrawn and call approve
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.WITHDRAWN)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.approve()
+
+    def test_transition_not_allowed_started_withdrawn(self):
+        """Create an application with status started and call withdraw
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.STARTED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.withdraw()
+
+    def test_transition_not_allowed_approved_withdrawn(self):
+        """Create an application with status approved and call withdraw
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.APPROVED)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.withdraw()
+
+    def test_transition_not_allowed_withdrawn_withdrawn(self):
+        """Create an application with status withdrawn and call withdraw
+        against transition rules"""
+
+        application = completed_application(status=DomainApplication.WITHDRAWN)
+
+        with self.assertRaises(TransitionNotAllowed):
+            application.withdraw()
 
 
 class TestPermissions(TestCase):


### PR DESCRIPTION
## 🗣 Description ##

- Define all status transitions in application admin class, 
- Implement approved email notification, 
- Refactor email methods in application model class from DRYer code, 
- Unit test emails as side-effects of status change and admin save,
- Unit tests against transitions that are not allowed

## 💭 Motivation and context ##

- Solves [422](https://github.com/cisagov/getgov/issues/442) and [722](https://github.com/cisagov/getgov/issues/722)
- Establishes infrastructure for further work on Domain Application status changes and flows