### PR TITLE
Remove `(optional)` from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -43,7 +43,7 @@ body:
   - type: textarea
     id: environment
     attributes:
-      label: Environment (optional)
+      label: Environment
       description: |
         Where is this issue occurring? If related to development environment, list the relevant tool versions.
         
@@ -54,12 +54,12 @@ body:
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Context (optional)
+      label: Additional Context
       description: "Please include additional references (screenshots, design links, documentation, etc.) that are relevant"
   - type: textarea
     id: issue-links
     attributes:
-      label: Issue Links (optional)
+      label: Issue Links
       description: |
         What other issues does this story relate to and how?
         

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -47,12 +47,12 @@ body:
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Context (optional)
+      label: Additional Context
       description: "Please include additional references (screenshots, design links, documentation, etc.) that are relevant"
   - type: textarea
     id: issue-links
     attributes:
-      label: Issue Links (optional)
+      label: Issue Links
       description: |
         What other issues does this story relate to and how?
         


### PR DESCRIPTION
# Remove `(optional)` from issue templates

## 🗣 Description ##

Removes the `(optional)` content that I had added following non-required questions. Now the absence of the red `*` next to a question will need to be the indicator of what is optional and not

## 💭 Motivation and context ##

The team noted that the `(optional)` showing up in created issues looks wonky, so let's remove it from the question text so that it does not transfer into created issues.
