### PR TITLE
Fix bug in approved domain notification

### DIFF
--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -598,7 +598,7 @@ class DomainApplication(TimeStampedModel):
             self._send_status_update_email(
                 "application approved",
                 "emails/status_change_approved.txt",
-                "emails/status_change_approved.txt",
+                "emails/status_change_approved_subject.txt",
             )
 
     @transition(field="status", source=[SUBMITTED, INVESTIGATING], target=WITHDRAWN)


### PR DESCRIPTION
## 🗣 Description ##

Fix typo in argument passed to the email sending method for approved domains. This bug is triggered when an email send is triggered in fixtures loading, not django admin.