### PR TITLE
Session bug fix

### DIFF
--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -150,7 +150,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         type_result = type_page.form.submit()
         # should see results in db
         application = DomainApplication.objects.get()  # there's only one
-
         self.assertEqual(application.organization_type, "federal")
         # the post request should return a redirect to the next form in
         # the application
@@ -168,7 +167,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
         federal_result = federal_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -182,7 +180,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- ORG CONTACT PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
         org_contact_page = federal_result.follow()
         org_contact_form = org_contact_page.form
         # federal agency so we have to fill in federal_agency
@@ -199,7 +196,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
         org_contact_result = org_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -221,7 +217,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- AUTHORIZING OFFICIAL PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
         ao_page = org_contact_result.follow()
         ao_form = ao_page.form
         ao_form["authorizing_official-first_name"] = "Testy ATO"

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -130,7 +130,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         As we add additional form pages, we need to include them here to make
         this test work.
         """
-        print("in form submission")
         num_pages_tested = 0
         # elections, type_of_work, tribal_government, no_other_contacts
         SKIPPED_PAGES = 4
@@ -142,39 +141,26 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # of a "session". We are going to do it manually, saving the session ID here
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        session_wizard=self.app.session['wizard_application']
-        
-        try:
-            print(self.app.session)
-            print(self.app.session.items())
-        except:
-            print("cant print session")
-            print(self.app)
 
         # ---- TYPE PAGE  ----
         type_form = type_page.form
         type_form["organization_type-organization_type"] = "federal"
-        print("submitting form with federal")
         # test next button and validate data
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         type_result = type_page.form.submit()
         # should see results in db
         application = DomainApplication.objects.get()  # there's only one
-        print("domain application is %s", str(application))
+
         self.assertEqual(application.organization_type, "federal")
         # the post request should return a redirect to the next form in
         # the application
-        print("going to organization federal")
         self.assertEqual(type_result.status_code, 302)
         self.assertEqual(type_result["Location"], "/register/organization_federal/")
         num_pages_tested += 1
 
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
-        print("clicking exective")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         federal_page = type_result.follow()
         federal_form = federal_page.form
@@ -182,7 +168,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         federal_result = federal_form.submit()
         # validate that data from this step are being saved
@@ -190,7 +175,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.assertEqual(application.federal_type, "executive")
         # the post request should return a redirect to the next form in
         # the application
-        print("clicking contact")
         self.assertEqual(federal_result.status_code, 302)
         self.assertEqual(federal_result["Location"], "/register/organization_contact/")
         num_pages_tested += 1
@@ -198,7 +182,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- ORG CONTACT PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         org_contact_page = federal_result.follow()
         org_contact_form = org_contact_page.form
@@ -216,7 +199,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         org_contact_result = org_contact_form.submit()
         # validate that data from this step are being saved
@@ -239,7 +221,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- AUTHORIZING OFFICIAL PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         ao_page = org_contact_result.follow()
         ao_form = ao_page.form
@@ -251,7 +232,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard 
         ao_result = ao_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -269,14 +249,12 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- CURRENT SITES PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         current_sites_page = ao_result.follow()
         current_sites_form = current_sites_page.form
         current_sites_form["current_sites-0-website"] = "www.city.com"
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         current_sites_result = current_sites_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -293,14 +271,12 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- DOTGOV DOMAIN PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         dotgov_page = current_sites_result.follow()
         dotgov_form = dotgov_page.form
         dotgov_form["dotgov_domain-requested_domain"] = "city"
         dotgov_form["dotgov_domain-0-alternative_domain"] = "city1"
 
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         dotgov_result = dotgov_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -317,14 +293,12 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- PURPOSE PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         purpose_page = dotgov_result.follow()
         purpose_form = purpose_page.form
         purpose_form["purpose-purpose"] = "For all kinds of things."
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         purpose_result = purpose_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -338,7 +312,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- YOUR CONTACT INFO PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         your_contact_page = purpose_result.follow()
         your_contact_form = your_contact_page.form
 
@@ -350,7 +323,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         your_contact_result = your_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -368,7 +340,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- OTHER CONTACTS PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         other_contacts_page = your_contact_result.follow()
         other_contacts_form = other_contacts_page.form
 
@@ -380,7 +351,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         other_contacts_result = other_contacts_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -410,7 +380,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         anything_else_result = anything_else_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -424,7 +393,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- REQUIREMENTS PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         requirements_page = anything_else_result.follow()
         requirements_form = requirements_page.form
 
@@ -445,7 +413,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- REVIEW AND FINSIHED PAGES  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         review_page = requirements_result.follow()
         review_form = review_page.form
 
@@ -482,7 +449,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # final submission results in a redirect to the "finished" URL
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         with less_console_noise():
             review_result = review_form.submit()
 
@@ -493,7 +459,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # following this redirect is a GET request, so include the cookie
         # here too.
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         with less_console_noise():
             final_result = review_result.follow()
         self.assertContains(final_result, "Thanks for your domain request!")
@@ -525,16 +490,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # type_page = home_page.click("Edit")
 
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        session_wizard=self.app.session['wizard_application']
+        session_wizard = self.app.session["wizard_application"]
         url = reverse("edit-application", kwargs={"id": application.pk})
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
 
         # TODO: The following line results in a django error on middleware
         response = self.client.get(url, follow=True)
         self.assertContains(response, "Type of organization")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        self.app.session["wizard_application"]=session_wizard
         # TODO: Step through the remaining pages
 
         self.assertEqual(num_pages, num_pages_tested)

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -490,7 +490,6 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # type_page = home_page.click("Edit")
 
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        session_wizard = self.app.session["wizard_application"]
         url = reverse("edit-application", kwargs={"id": application.pk})
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
 

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -130,6 +130,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         As we add additional form pages, we need to include them here to make
         this test work.
         """
+        print("in form submission")
         num_pages_tested = 0
         # elections, type_of_work, tribal_government, no_other_contacts
         SKIPPED_PAGES = 4
@@ -141,38 +142,55 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # of a "session". We are going to do it manually, saving the session ID here
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        session_wizard=self.app.session['wizard_application']
+        
+        try:
+            print(self.app.session)
+            print(self.app.session.items())
+        except:
+            print("cant print session")
+            print(self.app)
 
         # ---- TYPE PAGE  ----
         type_form = type_page.form
         type_form["organization_type-organization_type"] = "federal"
-
+        print("submitting form with federal")
         # test next button and validate data
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         type_result = type_page.form.submit()
         # should see results in db
         application = DomainApplication.objects.get()  # there's only one
+        print("domain application is %s", str(application))
         self.assertEqual(application.organization_type, "federal")
         # the post request should return a redirect to the next form in
         # the application
+        print("going to organization federal")
         self.assertEqual(type_result.status_code, 302)
         self.assertEqual(type_result["Location"], "/register/organization_federal/")
         num_pages_tested += 1
 
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
+        print("clicking exective")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
+
         federal_page = type_result.follow()
         federal_form = federal_page.form
         federal_form["organization_federal-federal_type"] = "executive"
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
+
         federal_result = federal_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
         self.assertEqual(application.federal_type, "executive")
         # the post request should return a redirect to the next form in
         # the application
+        print("clicking contact")
         self.assertEqual(federal_result.status_code, 302)
         self.assertEqual(federal_result["Location"], "/register/organization_contact/")
         num_pages_tested += 1
@@ -180,6 +198,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- ORG CONTACT PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
+
         org_contact_page = federal_result.follow()
         org_contact_form = org_contact_page.form
         # federal agency so we have to fill in federal_agency
@@ -196,6 +216,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
+
         org_contact_result = org_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -217,6 +239,8 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- AUTHORIZING OFFICIAL PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
+
         ao_page = org_contact_result.follow()
         ao_form = ao_page.form
         ao_form["authorizing_official-first_name"] = "Testy ATO"
@@ -227,6 +251,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard 
         ao_result = ao_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -244,12 +269,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- CURRENT SITES PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         current_sites_page = ao_result.follow()
         current_sites_form = current_sites_page.form
         current_sites_form["current_sites-0-website"] = "www.city.com"
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         current_sites_result = current_sites_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -266,12 +293,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- DOTGOV DOMAIN PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         dotgov_page = current_sites_result.follow()
         dotgov_form = dotgov_page.form
         dotgov_form["dotgov_domain-requested_domain"] = "city"
         dotgov_form["dotgov_domain-0-alternative_domain"] = "city1"
 
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         dotgov_result = dotgov_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -288,12 +317,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- PURPOSE PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         purpose_page = dotgov_result.follow()
         purpose_form = purpose_page.form
         purpose_form["purpose-purpose"] = "For all kinds of things."
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         purpose_result = purpose_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -307,6 +338,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- YOUR CONTACT INFO PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         your_contact_page = purpose_result.follow()
         your_contact_form = your_contact_page.form
 
@@ -318,6 +350,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         your_contact_result = your_contact_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -335,6 +368,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- OTHER CONTACTS PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         other_contacts_page = your_contact_result.follow()
         other_contacts_form = other_contacts_page.form
 
@@ -346,6 +380,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         other_contacts_result = other_contacts_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -375,6 +410,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         anything_else_result = anything_else_form.submit()
         # validate that data from this step are being saved
         application = DomainApplication.objects.get()  # there's only one
@@ -388,6 +424,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- REQUIREMENTS PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         requirements_page = anything_else_result.follow()
         requirements_form = requirements_page.form
 
@@ -408,6 +445,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # ---- REVIEW AND FINSIHED PAGES  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         review_page = requirements_result.follow()
         review_form = review_page.form
 
@@ -444,6 +482,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # final submission results in a redirect to the "finished" URL
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         with less_console_noise():
             review_result = review_form.submit()
 
@@ -454,6 +493,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # following this redirect is a GET request, so include the cookie
         # here too.
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         with less_console_noise():
             final_result = review_result.follow()
         self.assertContains(final_result, "Thanks for your domain request!")
@@ -485,13 +525,16 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # type_page = home_page.click("Edit")
 
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        session_wizard=self.app.session['wizard_application']
         url = reverse("edit-application", kwargs={"id": application.pk})
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
 
         # TODO: The following line results in a django error on middleware
         response = self.client.get(url, follow=True)
         self.assertContains(response, "Type of organization")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        self.app.session["wizard_application"]=session_wizard
         # TODO: Step through the remaining pages
 
         self.assertEqual(num_pages, num_pages_tested)

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -141,7 +141,6 @@ class ApplicationWizard(TemplateView):
             except DomainApplication.DoesNotExist:
                 logger.debug("Application id %s did not have a DomainApplication" % id)
 
-        ##not being called for the new application when one
         self._application = DomainApplication.objects.create(
             creator=self.request.user,  # type: ignore
         )
@@ -214,7 +213,7 @@ class ApplicationWizard(TemplateView):
         #     send users "to the application wizard" without needing to
         #     know which view is first in the list of steps.
         if self.__class__ == ApplicationWizard:
-         
+            #if starting a new application, clear the storage
             if request.path_info == self.NEW_URL_NAME:
                 del self.storage
                 self.storage["application_id"] = None #reset the app
@@ -247,15 +246,14 @@ class ApplicationWizard(TemplateView):
         and from the database if `use_db` is True (provided that record exists).
         An empty form will be provided if neither of those are true.
         """
-        ##bug is here an empty form is not provided if these are false!!!
         kwargs = {
             "files": files,
             "prefix": self.steps.current,
             "application": self.application,  # this is a property, not an object
-        }##application here causing the issue?
+        }
 
         if step is None:
-            forms = self.forms ##what dis?
+            forms = self.forms
         else:
             url = reverse(f"{self.URL_NAMESPACE}:{step}")
             forms = resolve(url).func.view_class.forms

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -133,22 +133,19 @@ class ApplicationWizard(TemplateView):
         if self.has_pk():
             id = self.storage["application_id"]
             try:
-                logger.debug("Trying to get the application")
                 self._application = DomainApplication.objects.get(
                     creator=self.request.user,  # type: ignore
                     pk=id,
                 )
-                logger.debug("applicaiton is %s",self._application)
                 return self._application
             except DomainApplication.DoesNotExist:
                 logger.debug("Application id %s did not have a DomainApplication" % id)
-        logger.debug("creating application with next id")
+
         self._application = DomainApplication.objects.create(
             creator=self.request.user,  # type: ignore
         )
 
         self.storage["application_id"] = self._application.id
-        logger.debug("setting id to %s",self._application.id)
         return self._application
 
     @property
@@ -216,10 +213,9 @@ class ApplicationWizard(TemplateView):
         #     send users "to the application wizard" without needing to
         #     know which view is first in the list of steps.
         if self.__class__ == ApplicationWizard:
-            #if starting a new application, clear the storage
+            # if starting a new application, clear the storage
             if request.path_info == self.NEW_URL_NAME:
                 del self.storage
-                # self.storage["application_id"] = None #reset the app
 
             return self.goto(self.steps.first)
 

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -133,19 +133,22 @@ class ApplicationWizard(TemplateView):
         if self.has_pk():
             id = self.storage["application_id"]
             try:
+                logger.debug("Trying to get the application")
                 self._application = DomainApplication.objects.get(
                     creator=self.request.user,  # type: ignore
                     pk=id,
                 )
+                logger.debug("applicaiton is %s",self._application)
                 return self._application
             except DomainApplication.DoesNotExist:
                 logger.debug("Application id %s did not have a DomainApplication" % id)
-
+        logger.debug("creating application with next id")
         self._application = DomainApplication.objects.create(
             creator=self.request.user,  # type: ignore
         )
 
         self.storage["application_id"] = self._application.id
+        logger.debug("setting id to %s",self._application.id)
         return self._application
 
     @property
@@ -216,7 +219,7 @@ class ApplicationWizard(TemplateView):
             #if starting a new application, clear the storage
             if request.path_info == self.NEW_URL_NAME:
                 del self.storage
-                self.storage["application_id"] = None #reset the app
+                # self.storage["application_id"] = None #reset the app
 
             return self.goto(self.steps.first)
 

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -67,7 +67,7 @@ class ApplicationWizard(TemplateView):
     URL_NAMESPACE = "application"
     # name for accessing /application/<id>/edit
     EDIT_URL_NAME = "edit-application"
-    NEW_URL_NAME = "register"
+    NEW_URL_NAME = "/register/"
     # We need to pass our human-readable step titles as context to the templates.
     TITLES = {
         Step.ORGANIZATION_TYPE: _("Type of organization"),
@@ -147,7 +147,6 @@ class ApplicationWizard(TemplateView):
         )
 
         self.storage["application_id"] = self._application.id
-        logger.debug("applications id %s",str(self.storage["application_id"]))
         return self._application
 
     @property
@@ -159,7 +158,6 @@ class ApplicationWizard(TemplateView):
 
     @storage.setter
     def storage(self, value):
-        logger.debug("requested session is  %s",  str(self.request.session))
         self.request.session[self.prefix] = value
         self.request.session.modified = True
 
@@ -199,18 +197,15 @@ class ApplicationWizard(TemplateView):
 
     def get(self, request, *args, **kwargs):
         """This method handles GET requests."""
-        logger.debug("IN GET application")
         current_url = resolve(request.path_info).url_name
-        logger.debug("Current url is %s", current_url)
+
         # if user visited via an "edit" url, associate the id of the
         # application they are trying to edit to this wizard instance
         # and remove any prior wizard data from their session
         if current_url == self.EDIT_URL_NAME and "id" in kwargs:
-            logger.debug("Storage was %s", self.storage)
             del self.storage
             self.storage["application_id"] = kwargs["id"]
-            logger.debug("storage is now %s", str(self.storage))
-            logger.debug("id set to %s", kwargs["id"])
+
         # if accessing this class directly, redirect to the first step
         #     in other words, if `ApplicationWizard` is called as view
         #     directly by some redirect or url handler, we'll send users
@@ -219,24 +214,16 @@ class ApplicationWizard(TemplateView):
         #     send users "to the application wizard" without needing to
         #     know which view is first in the list of steps.
         if self.__class__ == ApplicationWizard:
-            ##hmmm could we use this to redirect users if they shouldn't view editable data?
-            ## this is where it resets to send to first 
-            #this is called when clicking an edit link AND when clicking new app
-            #not called when navigating between steps (such as clicking save and continue)
-            logger.debug("Current url is %s", current_url)
-            if current_url == self.NEW_URL_NAME:## find the right URL
-                logger.debug("In if check")
-
+         
+            if request.path_info == self.NEW_URL_NAME:
                 del self.storage
                 self.storage["application_id"] = None #reset the app
-            logger.debug("calling go to first step")
-            #del self.storage
+
             return self.goto(self.steps.first)
 
         self.steps.current = current_url
         context = self.get_context_data()
         context["forms"] = self.get_forms()
-        logger.debug("Context set to %s", str(context))
         return render(request, self.template_name, context)
 
     def get_all_forms(self, **kwargs) -> list:
@@ -329,7 +316,6 @@ class ApplicationWizard(TemplateView):
         """This method handles POST requests."""
         # if accessing this class directly, redirect to the first step
         if self.__class__ == ApplicationWizard:
-            logger.debug("post redirect to first steps")
             return self.goto(self.steps.first)
 
         # which button did the user press?


### PR DESCRIPTION
# Resolves #394  #

## 🗣 Description ##
-after editing an application, a new application can now be created
-the previous application's data should not appear on any pages

## 💭 Motivation and context ##
When a user had already been editing a previous application and returned to the home page, clicked start new application, then a bug showed where a new application was not actually created and instead the previous application was shown instead.


Note to PR reviewer, testing this was getting rather complicated with a unit test, so the test was skipped for time saving reasons. I think this one is fine for just manual testing and we can come back to upping unit test coverage later. Feel free to disagree and Request Changes