### PR TITLE
775 - Add a sublabel (with a link) to tribe locality from

### DIFF
--- a/src/registrar/templates/application_tribal_government.html
+++ b/src/registrar/templates/application_tribal_government.html
@@ -3,7 +3,15 @@
 
 
 {% block form_fields %}
-  {% input_with_errors forms.0.tribe_name %}
+
+  {% with sublabel_text="Please include the entire name of your tribe as recognized by the" %}
+    {% with link_text="Bureau of Indian Affairs" %}
+      {% with link_href="https://rachid.me" %}
+        {% input_with_errors forms.0.tribe_name %}
+      {% endwith %}
+    {% endwith %}
+  {% endwith %}
+
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">
       <p>Is your organization a federally-recognized tribe or a state-recognized tribe? Check all that apply.

--- a/src/registrar/templates/application_tribal_government.html
+++ b/src/registrar/templates/application_tribal_government.html
@@ -4,10 +4,12 @@
 
 {% block form_fields %}
 
-  {% with sublabel_text="Please include the entire name of your tribe as recognized by the" %}
+  {% with sublabel_text="Please include the entire name of your tribe as recognized by the Bureau of Indian Affairs." %}
     {% with link_text="Bureau of Indian Affairs" %}
-      {% with link_href="https://rachid.me" %}
-        {% input_with_errors forms.0.tribe_name %}
+      {% with link_href="https://www.federalregister.gov/documents/2023/01/12/2023-00504/indian-entities-recognized-by-and-eligible-to-receive-services-from-the-united-states-bureau-of" %}
+        {% with target_blank="true" %}
+          {% input_with_errors forms.0.tribe_name %}
+        {% endwith %}
       {% endwith %}
     {% endwith %}
   {% endwith %}

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -33,6 +33,8 @@
       </thead>
       <tbody>
         {% for domain in domains %}
+        {% comment %} ticket 796
+        {% if domain.application_status == "approved" or (domain.application does not exist)  %} {% endcomment %}
         <tr>
           <th th scope="row" role="rowheader" data-label="Domain name">
             {{ domain.name }}

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -29,7 +29,12 @@ error messages, if necessary.
   {% endif %}
 
   {% if sublabel_text %}
-    <p id="{{ widget.attrs.id }}__sublabel" class="text-base margin-top-2px margin-bottom-1">{{ sublabel_text }}</p>
+    <p id="{{ widget.attrs.id }}__sublabel" class="text-base margin-top-2px margin-bottom-1">
+      {{ sublabel_text }}
+      {% if link_text %}
+        <a href="{{ link_href }}">{{ link_text }}</a>.
+      {% endif %}
+    </p>
   {% endif %}
 
   {% if field.errors %}

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -32,7 +32,7 @@ error messages, if necessary.
 
   {% if sublabel_text %}
     <p id="{{ widget.attrs.id }}__sublabel" class="text-base margin-top-2px margin-bottom-1">
-      {% comment %} If the link_text appears twice, the first instance will be a link and the second instance will be ignored {% endcomment %}
+      {% comment %} If the link_text appears more than once, the first instance will be a link and the other instances will be ignored {% endcomment %}
       {% if link_text and link_text in sublabel_text %}
         {% with link_index=sublabel_text|find_index:link_text %}
           {{ sublabel_text|slice:link_index }}

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -3,6 +3,8 @@ Template include for form fields with classes and their corresponding
 error messages, if necessary.
 {% endcomment %}
 
+{% load custom_filters %}
+
 {% load widget_tweaks %}
 
 {% if widget.attrs.maxlength %}
@@ -30,12 +32,18 @@ error messages, if necessary.
 
   {% if sublabel_text %}
     <p id="{{ widget.attrs.id }}__sublabel" class="text-base margin-top-2px margin-bottom-1">
-      {{ sublabel_text }}
-      {% if link_text %}
-        <a href="{{ link_href }}">{{ link_text }}</a>.
+      {% comment %} If the link_text appears twice, the first instance will be a link and the second instance will be ignored {% endcomment %}
+      {% if link_text and link_text in sublabel_text %}
+        {% with link_index=sublabel_text|find_index:link_text %}
+          {{ sublabel_text|slice:link_index }}
+          {% comment %} HTML will convert a new line into a space, resulting with a space before the fullstop in case link_text is at the end of sublabel_text, hence the unfortunate line below {% endcomment %}
+          <a {% if target_blank == "true" %}target="_blank" {% endif %}href="{{ link_href }}">{{ link_text }}</a>{% with sublabel_part_after=sublabel_text|slice_after:link_text %}{{ sublabel_part_after }}{% endwith %}
+        {% endwith %}
+      {% else %}
+        {{ sublabel_text }}
       {% endif %}
     </p>
-  {% endif %}
+  {% endif %} 
 
   {% if field.errors %}
     <div id="{{ widget.attrs.id }}__error-message">

--- a/src/registrar/templatetags/custom_filters.py
+++ b/src/registrar/templatetags/custom_filters.py
@@ -23,3 +23,20 @@ def extract_a_text(value):
         extracted_text = ""
 
     return extracted_text
+
+
+@register.filter
+def find_index(haystack, needle):
+    try:
+        return haystack.index(needle)
+    except ValueError:
+        return -1
+
+
+@register.filter
+def slice_after(value, substring):
+    index = value.find(substring)
+    if index != -1:
+        result = value[index + len(substring) :]
+        return result
+    return value

--- a/src/registrar/tests/test_templatetags.py
+++ b/src/registrar/tests/test_templatetags.py
@@ -3,6 +3,12 @@
 from django.conf import settings
 from django.test import TestCase
 from django.template import Context, Template
+from registrar.templatetags.custom_filters import (
+    extract_value,
+    extract_a_text,
+    find_index,
+    slice_after,
+)
 
 
 class TestTemplateTags(TestCase):
@@ -33,8 +39,6 @@ class TestTemplateTags(TestCase):
 
 class CustomFiltersTestCase(TestCase):
     def test_extract_value_filter(self):
-        from registrar.templatetags.custom_filters import extract_value
-
         html_input = (
             '<input type="checkbox" name="_selected_action" value="123" '
             'id="label_123" class="action-select">'
@@ -50,8 +54,6 @@ class CustomFiltersTestCase(TestCase):
         self.assertEqual(result, "abc")
 
     def test_extract_a_text_filter(self):
-        from registrar.templatetags.custom_filters import extract_a_text
-
         input_text = '<a href="#">Link Text</a>'
         result = extract_a_text(input_text)
         self.assertEqual(result, "Link Text")
@@ -59,3 +61,25 @@ class CustomFiltersTestCase(TestCase):
         input_text = '<a href="/example">Another Link</a>'
         result = extract_a_text(input_text)
         self.assertEqual(result, "Another Link")
+
+    def test_find_index(self):
+        haystack = "Hello, World!"
+        needle = "lo"
+        result = find_index(haystack, needle)
+        self.assertEqual(result, 3)
+
+        needle = "XYZ"
+        result = find_index(haystack, needle)
+        self.assertEqual(result, -1)
+
+    def test_slice_after(self):
+        value = "Hello, World!"
+        substring = "lo"
+        result = slice_after(value, substring)
+        self.assertEqual(result, ", World!")
+
+        substring = "XYZ"
+        result = slice_after(value, substring)
+        self.assertEqual(
+            result, value
+        )  # Should return the original value if substring not found

--- a/src/registrar/views/utility/mixins.py
+++ b/src/registrar/views/utility/mixins.py
@@ -24,11 +24,12 @@ class DomainPermission(PermissionsLoginMixin):
         The user is in self.request.user and the domain needs to be looked
         up from the domain's primary key in self.kwargs["pk"]
         """
-        
+
         # ticket 806
-        # if self.request.user is staff or admin and domain.application__status = 'approved' or 'rejected' or 'action needed'
+        # if self.request.user is staff or admin and
+        # domain.application__status = 'approved' or 'rejected' or 'action needed'
         #     return True
-        
+
         if not self.request.user.is_authenticated:
             return False
 
@@ -37,10 +38,10 @@ class DomainPermission(PermissionsLoginMixin):
             user=self.request.user, domain__id=self.kwargs["pk"]
         ).exists():
             return False
-        
+
         # ticket 796
         # if domain.application__status != 'approved'
-        #     return false    
+        #     return false
 
         # if we need to check more about the nature of role, do it here.
         return True

--- a/src/registrar/views/utility/mixins.py
+++ b/src/registrar/views/utility/mixins.py
@@ -24,6 +24,11 @@ class DomainPermission(PermissionsLoginMixin):
         The user is in self.request.user and the domain needs to be looked
         up from the domain's primary key in self.kwargs["pk"]
         """
+        
+        # ticket 806
+        # if self.request.user is staff or admin and domain.application__status = 'approved' or 'rejected' or 'action needed'
+        #     return True
+        
         if not self.request.user.is_authenticated:
             return False
 
@@ -32,6 +37,10 @@ class DomainPermission(PermissionsLoginMixin):
             user=self.request.user, domain__id=self.kwargs["pk"]
         ).exists():
             return False
+        
+        # ticket 796
+        # if domain.application__status != 'approved'
+        #     return false    
 
         # if we need to check more about the nature of role, do it here.
         return True


### PR DESCRIPTION
## 🗣 Description ##

- Pass down a bunch of props to input-with-errors for such sublabels
- Build out the sublabel in input-with-errors using a couple of custom filters
- Unit tests for the custom filters only*

## 💭 Motivation and context ##

Resolves #775 

\* Note: Another unit test to make sure the template logic works as expected (including edge cases**) would be nice. 
** If the link_text appears more than once, the first instance will be a link and the other instances will be ignored
*** We should create a new ticket to polish this up with the unit test and the identified edge case (tagged later)