### PR TITLE
823 - Explore extending django components with uswds markup

### DIFF
--- a/src/registrar/templates/admin/app_list.html
+++ b/src/registrar/templates/admin/app_list.html
@@ -3,7 +3,7 @@
 {% if app_list %}
   {% for app in app_list %}
     <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
-      <table>
+      <table class="usa-table">
         <caption>
           <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
         </caption>

--- a/src/registrar/templates/admin/change_list_results.html
+++ b/src/registrar/templates/admin/change_list_results.html
@@ -20,10 +20,10 @@ Load our custom filters to extract info from the django generated markup.
 {# .gov - hardcode the select all checkbox #}
 <th scope="col" class="action-checkbox-column" title="Toggle all">
     <div class="text">
-        <span>
-            <input type="checkbox" name="_selected_action" id="action-toggle">
-            <label for="action-toggle" class="usa-sr-only">Toggle all</label>
-        </span>
+        <div class="usa-checkbox">
+            <input type="checkbox" name="_selected_action" id="action-toggle" class="usa-checkbox__input">
+            <label for="action-toggle" class="usa-checkbox__label"><span class="usa-sr-only">Toggle all</span></label>
+        </div>
     </div>
     <div class="clear"></div>
 </th>
@@ -72,8 +72,10 @@ checkboxes.
         {% with result_value=result.0|extract_value %}
             {% with result_label=result.1|extract_a_text %}
                 <td>
-                    <input type="checkbox" name="_selected_action" value="{{ result_value|default:'value' }}" id="{{ result_label|default:result_value }}" class="action-select">
-                    <label class="usa-sr-only" for="{{ result_label|default:result_value }}">{{ result_label|default:'label' }}</label>
+                    <div class="usa-checkbox">
+                        <input type="checkbox" name="_selected_action" value="{{ result_value|default:'value' }}" id="{{ result_label|default:result_value }}" class="action-select usa-checkbox__input">
+                        <label class="usa-checkbox__label" for="{{ result_label|default:result_value }}"><span class="usa-sr-only">{{ result_label|default:'label' }}</span></label>
+                    </div>    
                 </td>
                 {% endwith %}
         {% endwith %}

--- a/src/registrar/templates/admin/change_list_results.html
+++ b/src/registrar/templates/admin/change_list_results.html
@@ -13,7 +13,7 @@ Load our custom filters to extract info from the django generated markup.
 {% endif %}
 {% if results %}
 <div class="results override-change_list_results">
-<table id="result_list">
+<table id="result_list" class="usa-table usa-table--borderless usa-table--striped">
 <thead>
 <tr>
 


### PR DESCRIPTION
## 🗣 Description ##

- Test using uswds chackbox markup
- Test using uswds table markup

## 💭 Motivation and context ##

Resolves #823 
This is an exercise to scope-out overriding django admin's markup to use USWDS markup and CSS classes.
 
## Findings

- When possible: this should be done through extending the admin templates instead of overwriting them as that would come with a hefty maintenance cost.
- Implementing uswds tables worked out fine. It's an obvious improvement over djando's styles
- Implementing uswds checkboxes was problematic. The uswds generated markup stands out for being too large in the django admin context, and the sr-only classes on the labels needed removing since uswds generated markup pretty much == the labels (a workaround is to add sr-only span child elements). 
- I recommend considering merging the tables implementation if it looks good to designers after merging the CSS theming with this work, shelving other components and especially form components for later consideration.

![Screen Shot 2023-08-03 at 12 52 41 PM](https://github.com/cisagov/getgov/assets/107004823/6944f0f1-f70f-4e2e-a6fe-6274154bff54)

![Screen Shot 2023-08-03 at 12 58 09 PM](https://github.com/cisagov/getgov/assets/107004823/8b1cbfa3-d6c7-4d51-bc54-70f1196965e7)

## Decision

Use usa-table usa-table--borderless usa-table--striped on change_list_results
