### PR TITLE
Updated README.md to include adding an analyst

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -66,7 +66,7 @@ The endpoint /admin can be used to view and manage site content, including but n
 1. Login via login.gov
 2. Go to the home page and make sure you can see the part where you can submit an application
 3. Go to /admin and it will tell you that UUID is not authorized, copy that UUID for use in 4
-4. in src/registrar/fixtures.py add to the ADMINS list in that file by adding your UUID as your username along with your first and last name. See below:
+4. in src/registrar/fixtures.py add to the `ADMINS` list in that file by adding your UUID as your username along with your first and last name. See below:
 
 ```
  ADMINS = [
@@ -78,9 +78,30 @@ The endpoint /admin can be used to view and manage site content, including but n
         ...
  ]
 ```
+5. In the browser, navigate to /admin. To verify that all is working correctly, under "domain applications" you should see fake domains with various fake statuses.
 
-5. In the browser, navigate to /admins. To verify that all is working correctly, under "domain applications" you should see fake domains with various fake statuses.
+### Adding an Analyst to /admin
+Analysts are a variant of the admin role with limited permissions. The process for adding an Analyst is much the same as adding an admin:
 
+1. Login via login.gov (if you already exist as an admin, you will need to create a separate login.gov account for this: i.e. first.last+1@email.com)
+2. Go to the home page and make sure you can see the part where you can submit an application
+3. Go to /admin and it will tell you that UUID is not authorized, copy that UUID for use in 4 (this will be a different UUID than the one obtained from creating an admin)
+4. in src/registrar/fixtures.py add to the `STAFF` list in that file by adding your UUID as your username along with your first and last name. See below:
+
+```
+ STAFF = [
+        {
+            "username": "<UUID here>",
+            "first_name": "",
+            "last_name": "",
+        },
+        ...
+ ]
+```
+
+5. In the browser, navigate to /admin. To verify that all is working correctly, verify that you can only see a sub-section of the modules and some are set to view-only.
+
+Do note that if you wish to have both an analyst and admin account, append `-Analyst` to your first and last name. Example: `Bob-Analyst`
 ## Adding to CODEOWNERS (optional)
 
 The CODEOWNERS file sets the tagged individuals as default reviewers on any Pull Request that changes files that they are marked as owners of.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The current README.md does not detail the steps necessary to create an 'Analyst' user, which are largely similar to creating an admin user. I've detailed this process, and also made a small alteration to 'ADMINS' so that it stands out a bit better on the markdown
<!-- Describe the "what" of your changes in detail. -->
<!-- Please link to any relevant issues. -->

## 💭 Motivation and context ##
To better document internal processes
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->