### PR TITLE
864 - Fix text too light on certain pages in dark mode (user facing pages)

### DIFF
--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -106,16 +106,22 @@ html[data-theme="light"] {
 
     // Dark mode django (bug due to scss cascade) and USWDS tables
     .change-list .usa-table,
-    .change-list .usa-table--striped tbody tr:nth-child(odd) td {
-        color: var(--body-fg)!important;
+    .change-list .usa-table--striped tbody tr:nth-child(odd) td,
+    .change-list .usa-table--borderless thead th,
+    .change-list .usa-table thead td, 
+    .change-list .usa-table thead th {
+        color: var(--body-fg);
     }
 }
 
 // Firefox needs this to be specifically set
 html[data-theme="dark"] {
     .change-list .usa-table,
-    .change-list .usa-table--striped tbody tr:nth-child(odd) td {
-        color: var(--body-fg)!important;
+    .change-list .usa-table--striped tbody tr:nth-child(odd) td,
+    .change-list .usa-table--borderless thead th,
+    .change-list .usa-table thead td, 
+    .change-list .usa-table thead th {
+        color: var(--body-fg);
     }
 }
 

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -105,7 +105,6 @@ html[data-theme="light"] {
     }
 
     // Dark mode django (bug due to scss cascade) and USWDS tables
-    body,
     .change-list .usa-table,
     .change-list .usa-table--striped tbody tr:nth-child(odd) td {
         color: var(--body-fg)!important;
@@ -114,7 +113,6 @@ html[data-theme="light"] {
 
 // Firefox needs this to be specifically set
 html[data-theme="dark"] {
-    body,
     .change-list .usa-table,
     .change-list .usa-table--striped tbody tr:nth-child(odd) td {
         color: var(--body-fg)!important;

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -110,7 +110,9 @@ html[data-theme="light"] {
     .change-list .usa-table--borderless thead th,
     .change-list .usa-table thead td, 
     .change-list .usa-table thead th,
-    body.dashboard {
+    body.dashboard,
+    body.change-list,
+    body.change-form {
         color: var(--body-fg);
     }
 }
@@ -122,7 +124,9 @@ html[data-theme="dark"] {
     .change-list .usa-table--borderless thead th,
     .change-list .usa-table thead td, 
     .change-list .usa-table thead th,
-    body.dashboard {
+    body.dashboard,
+    body.change-list,
+    body.change-form {
         color: var(--body-fg);
     }
 }

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -109,7 +109,8 @@ html[data-theme="light"] {
     .change-list .usa-table--striped tbody tr:nth-child(odd) td,
     .change-list .usa-table--borderless thead th,
     .change-list .usa-table thead td, 
-    .change-list .usa-table thead th {
+    .change-list .usa-table thead th,
+    body.dashboard {
         color: var(--body-fg);
     }
 }
@@ -120,7 +121,8 @@ html[data-theme="dark"] {
     .change-list .usa-table--striped tbody tr:nth-child(odd) td,
     .change-list .usa-table--borderless thead th,
     .change-list .usa-table thead td, 
-    .change-list .usa-table thead th {
+    .change-list .usa-table thead th,
+    body.dashboard {
         color: var(--body-fg);
     }
 }


### PR DESCRIPTION
## 🗣 Description ##

- Remove broad 'body' CSS selector when setting color in dark mode (initially, to fix text too dark on change_list_results tables)
- Tested locally in django admin and on user facing pages, using system and django admin dark/light mode toggles.

## 💭 Motivation and context ##

Closes #864 