### PR TITLE
839 - Fix missing column in django admin for Staff users

### DIFF
--- a/src/registrar/templates/admin/change_list_results.html
+++ b/src/registrar/templates/admin/change_list_results.html
@@ -13,57 +13,49 @@ Load our custom filters to extract info from the django generated markup.
 {% endif %}
 {% if results %}
 <div class="results override-change_list_results">
-<table id="result_list" class="usa-table usa-table--borderless usa-table--striped">
+<table id="result_list">
 <thead>
 <tr>
 
-{# .gov - hardcode the select all checkbox #}
-<th scope="col" class="action-checkbox-column" title="Toggle all">
-    <div class="text">
-        <span>
-            <input type="checkbox" name="_selected_action" id="action-toggle">
-            <label for="action-toggle" class="usa-sr-only">Toggle all</label>
-        </span>
-    </div>
-    <div class="clear"></div>
-</th>
-{# .gov - don't let django generate the select all checkbox #}
-{% for header in result_headers|slice:"1:" %}
+{% if results.0.form %}
+    {# .gov - hardcode the select all checkbox #}
+    <th scope="col" class="action-checkbox-column" title="Toggle all">
+        <div class="text">
+            <span>
+                <input type="checkbox" name="_selected_action" id="action-toggle">
+                <label for="action-toggle" class="usa-sr-only">Toggle all</label>
+            </span>
+        </div>
+        <div class="clear"></div>
+    </th>
+    {# .gov - don't let django generate the select all checkbox #}
+    {% for header in result_headers|slice:"1:" %}  
+        <th scope="col"{{ header.class_attrib }}>
+        {% if header.sortable %}
+            {% if header.sort_priority > 0 %}
+            <div class="sortoptions">
+                <a class="sortremove" href="{{ header.url_remove }}" title="{% translate "Remove from sorting" %}"></a>
+                {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktranslate with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktranslate %}">{{ header.sort_priority }}</span>{% endif %}
+                <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate "Toggle sorting" %}"></a>
+            </div>
+            {% endif %}
+        {% endif %}
+        <div class="text">{% if header.sortable %}<a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
+        <div class="clear"></div>
+    </th>{% endfor %}
 
-<th scope="col"{{ header.class_attrib }}>
-   {% if header.sortable %}
-     {% if header.sort_priority > 0 %}
-       <div class="sortoptions">
-         <a class="sortremove" href="{{ header.url_remove }}" title="{% translate "Remove from sorting" %}"></a>
-         {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktranslate with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktranslate %}">{{ header.sort_priority }}</span>{% endif %}
-         <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate "Toggle sorting" %}"></a>
-       </div>
-     {% endif %}
-   {% endif %}
-   <div class="text">{% if header.sortable %}<a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
-   <div class="clear"></div>
-</th>{% endfor %}
+    </tr>
+    </thead>
+    <tbody>
 
-</tr>
-</thead>
-<tbody>
+    {% comment %}
+    .gov - hardcode the row checkboxes using the custom filters to extract
+    the value attribute's value, and a label based on the anchor elements's
+    text. Then edit the for loop to keep django from generating the row select 
+    checkboxes.
+    {% endcomment %}
 
-{% comment %} 
-{% for result in results %}
-{% if result.form.non_field_errors %}
-    <tr><td colspan="{{ result|length }}">{{ result.form.non_field_errors }}</td></tr>
-{% endif %}
-<tr>{% for item in result %}{{ item }}{% endfor %}</tr>
-{% endfor %} 
-{% endcomment %}
-
-{% comment %}
-.gov - hardcode the row checkboxes using the custom filters to extract
-the value attribute's value, and a label based on the anchor elements's
-text. Then edit the for loop to keep django from generating the row select 
-checkboxes.
-{% endcomment %}
-{% for result in results %}
+    {% for result in results %}
     {% if result.form.non_field_errors %}
         <tr><td colspan="{{ result|length }}">{{ result.form.non_field_errors }}</td></tr>
     {% endif %}
@@ -82,7 +74,37 @@ checkboxes.
             {{ item }}
         {% endfor %}
     </tr>
-{% endfor %}
+    {% endfor %}
+
+{% else %}
+    
+    {% for header in result_headers %}  
+    <th scope="col"{{ header.class_attrib }}>
+    {% if header.sortable %}
+        {% if header.sort_priority > 0 %}
+        <div class="sortoptions">
+            <a class="sortremove" href="{{ header.url_remove }}" title="{% translate "Remove from sorting" %}"></a>
+            {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktranslate with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktranslate %}">{{ header.sort_priority }}</span>{% endif %}
+            <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate "Toggle sorting" %}"></a>
+        </div>
+        {% endif %}
+    {% endif %}
+    <div class="text">{% if header.sortable %}<a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
+    <div class="clear"></div>
+    </th>{% endfor %}
+
+    </tr>
+    </thead>
+    <tbody>
+
+    {% for result in results %}
+        {% if result.form.non_field_errors %}
+            <tr><td colspan="{{ result|length }}">{{ result.form.non_field_errors }}</td></tr>
+        {% endif %}
+        <tr>{% for item in result %}{{ item }}{% endfor %}</tr>
+    {% endfor %}
+
+{% endif %}
 
 </tbody>
 </table>

--- a/src/registrar/templates/admin/change_list_results.html
+++ b/src/registrar/templates/admin/change_list_results.html
@@ -76,7 +76,7 @@ Load our custom filters to extract info from the django generated markup.
     </tr>
     {% endfor %}
 
-{% else %}
+{% else %} {# results doesn't have a form as its first element #}
     
     {% for header in result_headers %}  
     <th scope="col"{{ header.class_attrib }}>

--- a/src/registrar/templates/admin/change_list_results.html
+++ b/src/registrar/templates/admin/change_list_results.html
@@ -13,7 +13,7 @@ Load our custom filters to extract info from the django generated markup.
 {% endif %}
 {% if results %}
 <div class="results override-change_list_results">
-<table id="result_list">
+<table id="result_list" class="usa-table usa-table--borderless usa-table--striped">
 <thead>
 <tr>
 


### PR DESCRIPTION
## 🗣 Description ##

In our change_list_results template override, we slice the first item in the results list returned for each table row and replace it with a label+checkbox markup block that meets accessibility requirements. This woks for a user with admin permissions because that user has delete perms on the model, and so there's a delete action on these tables and checkboxes get generated for each table row to allow selection for the aforementioned action.

For a user with staff permissions, she can access these models in django admin but does not have any perms to delete (or otherwise populate the 'actions' dropdown), therefore the first item in the returned results set for each row in NOT a checkbox. The bug is a result of us slicing the first data element in the results set and replacing it with a useless checkbox.
 
The bug is fixed by checking to see if first item in the result set for a change_list_results table row is a form before performing the checkbox slice/markup switch. This should be resilient enough as the first item in a row is either a checkbox or data, and we'd want to replace any checkbox with accessible markup but leave data alone.

## 💭 Motivation and context ##

Closes #839 