### PR TITLE
881 - Troubleshooting notes for M1 Mac puppeteer issue

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -18,9 +18,14 @@ If you're new to Django, see [Getting Started with Django](https://www.djangopro
 
 Visit the running application at [http://localhost:8080](http://localhost:8080).
 
-Note: If you are using Windows, you may need to change your [line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings). If not, you may not be able to run manage.py. 
+**Note:** If you are using Windows, you may need to change your [line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings). If not, you may not be able to run manage.py. 
 * Unix based operating systems (like macOS or Linux) handle line separators [differently than Windows does](https://superuser.com/questions/374028/how-are-n-and-r-handled-differently-on-linux-and-windows). This can break bash scripts in particular. In the case of manage.py, it uses *#!/usr/bin/env python* to access the Python executable. Since the script is still thinking in terms of unix line seperators, it may look for the executable *python\r* rather than *python* (since Windows cannot read the carriage return on its own) - thus leading to the error `usr/bin/env: 'python\r' no such file or directory` 
 * If you'd rather not change this globally, add a `.gitattributes` file in the project root with `* text eol=lf` as the text content, and [refresh the repo](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings)
+**Note:** If you are using a Mac with a M1 chip, and see this error `The chromium binary is not available for arm64.` or an error invovling `puppeteer`, try adding this line below into your `.bashrc` or `.zshrc`
+
+```
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
 
 ## Branch Conventions
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -18,14 +18,19 @@ If you're new to Django, see [Getting Started with Django](https://www.djangopro
 
 Visit the running application at [http://localhost:8080](http://localhost:8080).
 
-**Note:** If you are using Windows, you may need to change your [line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings). If not, you may not be able to run manage.py. 
+
+### Troubleshooting 
+
+* If you are using Windows, you may need to change your [line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings). If not, you may not be able to run manage.py. 
 * Unix based operating systems (like macOS or Linux) handle line separators [differently than Windows does](https://superuser.com/questions/374028/how-are-n-and-r-handled-differently-on-linux-and-windows). This can break bash scripts in particular. In the case of manage.py, it uses *#!/usr/bin/env python* to access the Python executable. Since the script is still thinking in terms of unix line seperators, it may look for the executable *python\r* rather than *python* (since Windows cannot read the carriage return on its own) - thus leading to the error `usr/bin/env: 'python\r' no such file or directory` 
 * If you'd rather not change this globally, add a `.gitattributes` file in the project root with `* text eol=lf` as the text content, and [refresh the repo](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings)
-**Note:** If you are using a Mac with a M1 chip, and see this error `The chromium binary is not available for arm64.` or an error invovling `puppeteer`, try adding this line below into your `.bashrc` or `.zshrc`
+* If you are using a Mac with a M1 chip, and see this error `The chromium binary is not available for arm64.` or an error involving `puppeteer`, try adding this line below into your `.bashrc` or `.zshrc`. 
 
 ```
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 ```
+
+When completed, don't forget to rerun `docker-compose up`! 
 
 ## Branch Conventions
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

When I was trying to set up my local, I ran into these errors with certain Docker commands:

1. When I ran `docker-compose build` locally, I received the error:
```
> [node internal] load metadata for docker.io/cimg/node:current-browsers:
------
failed to solve: docker.io/cimg/node:current-browsers: no match for platform in manifest
```

2. When I ran `docker-compose up` locally, I received this error:
```
src-node-1  | npm ERR! path /app/node_modules/puppeteer
src-node-1  |
src-node-1  | npm ERR! command failed
src-node-1  | npm ERR! command sh -c node install.js
src-node-1  | npm ERR!
src-node-1  |  The chromium binary is not available for arm64.
src-node-1  | npm ERR! If you are on Ubuntu, you can install with:
src-node-1  | npm ERR!
src-node-1  | npm ERR!  sudo apt install chromium
src-node-1  | npm ERR!
src-node-1  | npm ERR!
src-node-1  | npm ERR!  sudo apt install chromium-browser
src-node-1  |
src-node-1  | npm ERR!
src-node-1  | npm ERR! /app/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:115
src-node-1  | npm ERR!                     throw new Error();
src-node-1  | npm ERR!                     ^
src-node-1  | npm ERR!
src-node-1  | npm ERR! Error
src-node-1  | npm ERR!     at /app/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:115:27
src-node-1  | npm ERR!     at FSReqCallback.oncomplete (node:fs:200:21)
src-node-1  | npm ERR!
src-node-1  | npm ERR!
src-node-1  |  Node.js v20.5.0
src-node-1  |
src-node-1  |
src-node-1  | npm
src-node-1  | ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-08-09T23_35_56_687Z-debug-0.log
```

Just added in a troubleshooting section in case anyone else runs into this issue on the M1 Mac :-)

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->