### PR TITLE
#794 - Za/794 fix admin logout issue

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -285,7 +285,7 @@ SERVER_EMAIL = "root@get.gov"
 
 # Content-Security-Policy configuration
 # this can be restrictive because we have few external scripts
-allowed_sources = ("'self'",)
+allowed_sources = ("'self'", "https://idp.int.identitysandbox.gov", "https://idp.int.identitysandbox.gov/openid_connect/logout")
 CSP_DEFAULT_SRC = allowed_sources
 # Most things fall back to default-src, but these two do not and should be
 # explicitly set

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -290,7 +290,7 @@ CSP_DEFAULT_SRC = allowed_sources
 # Most things fall back to default-src, but these two do not and should be
 # explicitly set
 CSP_FRAME_ANCESTORS = allowed_sources
-CSP_FORM_ACTION = ("'self'", "https://idp.int.identitysandbox.gov/openid_connect/logout")
+CSP_FORM_ACTION = allowed_sources
 
 
 # Content-Length header is set by django.middleware.common.CommonMiddleware

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -285,12 +285,12 @@ SERVER_EMAIL = "root@get.gov"
 
 # Content-Security-Policy configuration
 # this can be restrictive because we have few external scripts
-allowed_sources = ("'self'", "https://idp.int.identitysandbox.gov", "https://idp.int.identitysandbox.gov/openid_connect/logout")
+allowed_sources = ("'self'")
 CSP_DEFAULT_SRC = allowed_sources
 # Most things fall back to default-src, but these two do not and should be
 # explicitly set
 CSP_FRAME_ANCESTORS = allowed_sources
-CSP_FORM_ACTION = allowed_sources
+CSP_FORM_ACTION = ("'self'", "https://idp.int.identitysandbox.gov/openid_connect/logout")
 
 
 # Content-Length header is set by django.middleware.common.CommonMiddleware

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -285,7 +285,7 @@ SERVER_EMAIL = "root@get.gov"
 
 # Content-Security-Policy configuration
 # this can be restrictive because we have few external scripts
-allowed_sources = ("'self'")
+allowed_sources = ("'self'",)
 CSP_DEFAULT_SRC = allowed_sources
 # Most things fall back to default-src, but these two do not and should be
 # explicitly set

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -118,17 +118,6 @@ urlpatterns = [
     ),
 ]
 
-# What is the purpose of this?
-# This behaviour gets overwritten, so this doesn't do anything...
-# Login in particular
-if not settings.DEBUG:
-    urlpatterns += [
-        # redirect to login.gov
-        path(
-            "admin/login/", RedirectView.as_view(pattern_name="login", permanent=False)
-        ),
-    ]
-
 # we normally would guard these with `if settings.DEBUG` but tests run with
 # DEBUG = False even when these apps have been loaded because settings.DEBUG
 # was actually True. Instead, let's add these URLs any time we are able to

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -46,9 +46,9 @@ for step, view in [
 urlpatterns = [
     path("", views.index, name="home"),
     path(
-            "admin/logout/",
-            RedirectView.as_view(pattern_name="logout", permanent=False),
-        ),
+        "admin/logout/",
+        RedirectView.as_view(pattern_name="logout", permanent=False),
+    ),
     path("admin/", admin.site.urls),
     path(
         "application/<id>/edit/",
@@ -118,7 +118,9 @@ urlpatterns = [
     ),
 ]
 
-
+# What is the purpose of this?
+# This behaviour gets overwritten, so this doesn't do anything...
+# Login in particular
 if not settings.DEBUG:
     urlpatterns += [
         # redirect to login.gov

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     path("", views.index, name="home"),
     path(
             "admin/logout/",
-            RedirectView.as_view(url="/openid/logout", permanent=False),
+            RedirectView.as_view(pattern_name="logout", permanent=False),
         ),
     path("admin/", admin.site.urls),
     path(
@@ -124,11 +124,6 @@ if not settings.DEBUG:
         # redirect to login.gov
         path(
             "admin/login/", RedirectView.as_view(pattern_name="login", permanent=False)
-        ),
-        # redirect to login.gov
-        path(
-            "admin/logout/",
-            RedirectView.as_view(pattern_name="logout", permanent=False),
         ),
     ]
 

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -4,7 +4,6 @@ For more information see:
     https://docs.djangoproject.com/en/4.0/topics/http/urls/
 """
 
-from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -45,6 +45,10 @@ for step, view in [
 
 urlpatterns = [
     path("", views.index, name="home"),
+    path(
+            "admin/logout/",
+            RedirectView.as_view(url="/openid/logout", permanent=False),
+        ),
     path("admin/", admin.site.urls),
     path(
         "application/<id>/edit/",

--- a/src/registrar/templates/admin/base_site.html
+++ b/src/registrar/templates/admin/base_site.html
@@ -13,5 +13,20 @@
   {% include "admin/color_theme_toggle.html" %}
 {% endif %}
 {% endblock %}
-
+{% block userlinks %}
+  {% if site_url %}
+      <a href="{{ site_url }}">View site</a> /
+  {% endif %}
+  {% if user.is_active and user.is_staff %}
+      {% url 'django-admindocs-docroot' as docsroot %}
+      {% if docsroot %}
+          <a href="{{ docsroot }}">Documentation</a> /
+      {% endif %}
+  {% endif %}
+  {% if user.has_usable_password %}
+  <a href="{% url 'admin:password_change' %}">Change password</a> /
+  {% endif %}
+  <a href="{% url 'admin:logout' %}" id="admin-logout-button">Log out</a>
+  {% include "admin/color_theme_toggle.html" %}
+ {% endblock %}
 {% block nav-global %}{% endblock %}

--- a/src/registrar/templates/admin/base_site.html
+++ b/src/registrar/templates/admin/base_site.html
@@ -1,5 +1,6 @@
 {% extends "admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 
@@ -13,20 +14,25 @@
   {% include "admin/color_theme_toggle.html" %}
 {% endif %}
 {% endblock %}
+{% comment %}
+  This was copied from the 'userlinks' template, with a few minor changes.
+  You can find that here:
+  https://github.com/django/django/blob/d25f3892114466d689fd6936f79f3bd9a9acc30e/django/contrib/admin/templates/admin/base.html#L59
+{% endcomment %}
 {% block userlinks %}
   {% if site_url %}
-      <a href="{{ site_url }}">View site</a> /
+      <a href="{{ site_url }}">{% translate 'View site' %}</a> /
   {% endif %}
   {% if user.is_active and user.is_staff %}
       {% url 'django-admindocs-docroot' as docsroot %}
       {% if docsroot %}
-          <a href="{{ docsroot }}">Documentation</a> /
+          <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
       {% endif %}
   {% endif %}
   {% if user.has_usable_password %}
-  <a href="{% url 'admin:password_change' %}">Change password</a> /
+      <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
   {% endif %}
-  <a href="{% url 'admin:logout' %}" id="admin-logout-button">Log out</a>
+      <a href="{% url 'admin:logout' %}" id="admin-logout-button">{% translate 'Log out' %}</a>
   {% include "admin/color_theme_toggle.html" %}
  {% endblock %}
 {% block nav-global %}{% endblock %}


### PR DESCRIPTION
## 🗣 Description ##
***Changes:**
- Made an edit to the userlinks block to replace it with an <a> tag, rather than a form
- Changed the order of the 'admin/logout' redirect to persist higher up the list (due to a bug)
- Removed the redirect for 'admin/login' as it was not functional and not intended to be there

The logout button on /admin was not functional as it was using a form submission rather than a simple redirect to do so. This change makes alterations to block 'userlinks' in base_site.html, and modifies urls.py to accommodate this change (redirect view).

![image](https://github.com/cisagov/getgov/assets/141044360/f45e30bc-b116-4c5f-b91f-554032a79b47)


## 💭 Motivation and context ##
To satisfy #794 