### PR TITLE
Remove "Archive" from Domain Management dashboard - Za/861 remove archive

### DIFF
--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -43,13 +43,13 @@
           <td data-label="Status">{{ domain.application_status|title }}</td>
           <td>
             <a href="{% url "domain" pk=domain.pk %}">
-              <svg 
-                class="usa-icon" 
-                aria-hidden="true" 
-                focusable="false" 
-                role="img" 
+              <svg
+                class="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
                 width="24"
-              > 
+              >
                 <use xlink:href="{%static 'img/sprite.svg'%}#settings"></use>
               </svg>
                 Manage <span class="usa-sr-only">{{ domain.name }}</span>
@@ -115,14 +115,16 @@
       aria-live="polite"
     ></div>
     {% else %}
-    <p>You don't have any active domain requests right now</p> 
+    <p>You don't have any active domain requests right now</p>
     {% endif %}
     <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p>
   </section>
 
+  {# Note: Reimplement this later after MVP #}
+  <!--
   <section class="section--outlined tablet:grid-col-11 desktop:grid-col-10">
     <h2>Archived domains</h2>
-    <p>You don't have any archived domains</p> 
+    <p>You don't have any archived domains</p>
   </section>
 
   <section class="tablet:grid-col-11 desktop:grid-col-10">
@@ -132,7 +134,7 @@
       Export domains as csv
     </a>
   </section>
-
+  -->
 </div>
 
 {% else %} {# not user.is_authenticated #}

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -120,7 +120,7 @@
     {% endif %}
   </section>
 
-  {# Note: Reimplement this after MVP #}
+  {# Note: Reimplement this after MVP.. #}
   <!--
   <section class="section--outlined tablet:grid-col-11 desktop:grid-col-10">
     <h2>Archived domains</h2>

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -116,8 +116,8 @@
     ></div>
     {% else %}
     <p>You don't have any active domain requests right now</p>
-    {% endif %}
     <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p>
+    {% endif %}
   </section>
 
   {# Note: Reimplement this later after MVP #}

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -120,7 +120,7 @@
     {% endif %}
   </section>
 
-  {# Note: Reimplement this later after MVP #}
+  {# Note: Reimplement this after MVP #}
   <!--
   <section class="section--outlined tablet:grid-col-11 desktop:grid-col-10">
     <h2>Archived domains</h2>

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -126,6 +126,7 @@
     <h2>Archived domains</h2>
     <p>You don't have any archived domains</p>
   </section>
+  -->
 
   <!-- Note: Uncomment below when this is being implemented post-MVP -->
   <!-- <section class="tablet:grid-col-11 desktop:grid-col-10">
@@ -134,8 +135,8 @@
     <a href="{% url 'todo' %}" class="usa-button usa-button--outline">
       Export domains as csv
     </a>
-  </section> -->
-
+  </section>
+  -->
 </div>
 
 {% else %} {# not user.is_authenticated #}


### PR DESCRIPTION
## Ticket

Resolves [#861](https://github.com/cisagov/getgov/issues/861)
- Remove the archive table and only show the associated "start a new domain request" button when no active domain requests exist
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- The 'Archived Domains' section was commented out and a note was added regarding re-implementation post MVP
- Moved the 'Start a new domain request' button inside the else block for '{% if domain_applications %}'  

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Questions for reviewers
- There is a particular edge case where the "start a new domain request" button is displayed twice when no Active Domains exist. The fix for this is pretty simple (not showing that button when there are no active domains), but I am not sure if this is intentional or not as the Figma does not denote this. For the designers, is this something that I should fix? (See screenshots)
- The attached figma on the [ticket](https://github.com/cisagov/getgov/issues/861) makes note of the bug were domains of status approved are duplicated in both tables. This was fixed [here](https://github.com/cisagov/getgov/pull/885), but the ticket was closed. Does this fix need to be added for this ticket?
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [x] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots
![image](https://github.com/cisagov/getgov/assets/141044360/8a3dd1c6-52c7-4506-960c-b0962f1da4f3)
![image](https://github.com/cisagov/getgov/assets/141044360/da472adb-98a4-486c-bd0e-029128b18298)

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
