### PR TITLE
796 - Filter applications by excluding approved ones, homepage

### DIFF
--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1500,3 +1500,18 @@ class TestApplicationStatus(TestWithUser, WebTest):
                         reverse(url_name, kwargs={"pk": application.pk})
                     )
                     self.assertEqual(page.status_code, 403)
+
+    def test_approved_application_not_in_active_requests(self):
+        """An approved application is not shown in the Active
+        Requests table on home.html."""
+        application = completed_application(
+            status=DomainApplication.APPROVED, user=self.user
+        )
+        application.save()
+
+        home_page = self.app.get("/")
+        # This works in our test environment because creating
+        # an approved application here does not generate a
+        # domain object, so we do not expect to see 'city.gov'
+        # in either the Domains or Requests tables.
+        self.assertNotContains(home_page, "city.gov")

--- a/src/registrar/views/index.py
+++ b/src/registrar/views/index.py
@@ -10,7 +10,7 @@ def index(request):
     if request.user.is_authenticated:
         applications = DomainApplication.objects.filter(creator=request.user)
         # Let's exclude the approved applications since our
-        # domain_applications context will be used to populate 
+        # domain_applications context will be used to populate
         # the active applications table
         context["domain_applications"] = applications.exclude(status="approved")
 


### PR DESCRIPTION
## Ticket

Resolves #796 

## Changes

- Filter out requests by excluding those with status approved for the homepage context
- Unit test looking for assertNotEqual when there's an approved request

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user