### PR TITLE
931 - Updates to Dashboard table titles on Home

### DIFF
--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -19,7 +19,7 @@
   </p>
 
   <section class="section--outlined tablet:grid-col-11 desktop:grid-col-10">
-    <h2>Registered domains</h2>
+    <h2>Domains</h2>
     {% if domains %}
     <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
       <caption class="sr-only">Your registered domains</caption>
@@ -67,7 +67,7 @@
   </section>
 
   <section class="section--outlined tablet:grid-col-11 desktop:grid-col-10">
-    <h2>Active domain requests</h2>
+    <h2>Domain requests</h2>
     {% if domain_applications %}
     <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
       <caption class="sr-only">Your domain applications</caption>


### PR DESCRIPTION
## Ticket

Resolves #931 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated titles to domain and domain request tables in domain dashboard

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

This PR resolves #931. Because we have removed the Archive section for MVP, the titles of these tables should reflect that they can have all types of domains + domain requests (including deleted). So calling these tables 'Registered domains' and 'Active domain requests' does not accurately reflect the content you'd find within them.

This is just a simple content update, doesn't seem to need a full checklist review, but pls tell me if I'm wrong

_Please frame images to show useful context but also highlight the affected regions._
--->
