### PR TITLE
Update default mail-sending address to help@get.gov

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -251,7 +251,7 @@ AWS_MAX_ATTEMPTS = 3
 BOTO_CONFIG = Config(retries={"mode": AWS_RETRY_MODE, "max_attempts": AWS_MAX_ATTEMPTS})
 
 # email address to use for various automated correspondence
-DEFAULT_FROM_EMAIL = "help@get.gov"
+DEFAULT_FROM_EMAIL = "help@get.gov <help@get.gov>"
 
 # connect to an (external) SMTP server for sending email
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -251,8 +251,7 @@ AWS_MAX_ATTEMPTS = 3
 BOTO_CONFIG = Config(retries={"mode": AWS_RETRY_MODE, "max_attempts": AWS_MAX_ATTEMPTS})
 
 # email address to use for various automated correspondence
-# TODO: pick something sensible here
-DEFAULT_FROM_EMAIL = "registrar@get.gov"
+DEFAULT_FROM_EMAIL = "help@get.gov"
 
 # connect to an (external) SMTP server for sending email
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
We [decided against](https://cisa-corp.slack.com/archives/C03QM0JGSQG/p1679670728147489?thread_ts=1679670277.935509&cid=C03QM0JGSQG) a "no-reply" style email address and will send automated notification from an address we'll actually use. We actually want to communicate with our users!

This PR changes our SES settings to send from `help@get.gov` instead of `registrar@get.gov`. 