### PR TITLE
898 - Django admin semantic markup for ADD and HISTORY links

### DIFF
--- a/src/registrar/fixtures.py
+++ b/src/registrar/fixtures.py
@@ -268,10 +268,11 @@ class DomainApplicationFixture:
             "status": "action needed",
             "organization_name": "Example - Action Needed",
         },
-        {
-            "status": "rejected",
-            "organization_name": "Example - Rejected",
-        },
+        # Pa11y does not like this fixture
+        # {
+        #     "status": "rejected",
+        #     "organization_name": "Example - Rejected",
+        # },
     ]
 
     @classmethod

--- a/src/registrar/fixtures.py
+++ b/src/registrar/fixtures.py
@@ -268,11 +268,10 @@ class DomainApplicationFixture:
             "status": "action needed",
             "organization_name": "Example - Action Needed",
         },
-        # Pa11y does not like this fixture
-        # {
-        #     "status": "rejected",
-        #     "organization_name": "Example - Rejected",
-        # },
+        {
+            "status": "rejected",
+            "organization_name": "Example - Rejected",
+        },
     ]
 
     @classmethod

--- a/src/registrar/templates/admin/change_form.html
+++ b/src/registrar/templates/admin/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools %}
+{% if change and not is_popup %}
+    <p class="object-tools">
+        {% block object-tools-items %}
+            {{ block.super }}
+        {% endblock %}
+    </p>
+{% endif %}
+{% endblock %}

--- a/src/registrar/templates/admin/change_form.html
+++ b/src/registrar/templates/admin/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_form.html" %}
 
-{% comment %} Replace the Django ul markup with a div. We'll edit the child markup accordingly in form_list_object_tools {% endcomment %}
+{% comment %} Replace the Django ul markup with a div. We'll edit the child markup accordingly in change_form_object_tools {% endcomment %}
 {% block object-tools %}
 {% if change and not is_popup %}
     <div class="object-tools">

--- a/src/registrar/templates/admin/change_form.html
+++ b/src/registrar/templates/admin/change_form.html
@@ -1,11 +1,12 @@
 {% extends "admin/change_form.html" %}
 
+{% comment %} Replace the Django ul markup with a div. We'll edit the child markup accordingly in form_list_object_tools {% endcomment %}
 {% block object-tools %}
 {% if change and not is_popup %}
-    <p class="object-tools">
+    <div class="object-tools">
         {% block object-tools-items %}
             {{ block.super }}
         {% endblock %}
-    </p>
+    </div>
 {% endif %}
 {% endblock %}

--- a/src/registrar/templates/admin/change_form_object_tools.html
+++ b/src/registrar/templates/admin/change_form_object_tools.html
@@ -1,7 +1,20 @@
 {% load i18n admin_urls %}
 
+{% comment %} Replace li with p for more semantic HTML if we have a single child {% endcomment %}
 {% block object-tools-items %}
-{% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
-<a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
-{% if has_absolute_url %}<a href="{{ absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}
+    {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+    {% if has_absolute_url %}
+        <ul>
+            <li>
+                <a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
+            </li>
+            <li>
+                <a href="{{ absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>
+            </li>
+        </ul>
+    {% else %}
+        <p class="margin-0 padding-0">
+            <a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
+        </p>
+    {% endif %}
 {% endblock %}

--- a/src/registrar/templates/admin/change_form_object_tools.html
+++ b/src/registrar/templates/admin/change_form_object_tools.html
@@ -1,0 +1,7 @@
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+{% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+<a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
+{% if has_absolute_url %}<a href="{{ absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a>{% endif %}
+{% endblock %}

--- a/src/registrar/templates/admin/change_list.html
+++ b/src/registrar/templates/admin/change_list.html
@@ -25,10 +25,11 @@
     </h2>    
 {% endblock %}
 
+{% comment %} Replace the Django ul markup with a div. We'll replace the li with a p in change_list_object_tools {% endcomment %}
 {% block object-tools %}
-    <p class="object-tools">
+    <div class="object-tools">
         {% block object-tools-items %}
             {{ block.super }}
         {% endblock %}
-    </p>
+    </div>
 {% endblock %}

--- a/src/registrar/templates/admin/change_list.html
+++ b/src/registrar/templates/admin/change_list.html
@@ -24,3 +24,11 @@
         {% endif %}
     </h2>    
 {% endblock %}
+
+{% block object-tools %}
+    <p class="object-tools">
+        {% block object-tools-items %}
+            {{ block.super }}
+        {% endblock %}
+    </p>
+{% endblock %}

--- a/src/registrar/templates/admin/change_list_object_tools.html
+++ b/src/registrar/templates/admin/change_list_object_tools.html
@@ -1,10 +1,13 @@
 {% load i18n admin_urls %}
 
+{% comment %} Replace li with p for more semantic HTML {% endcomment %}
 {% block object-tools-items %}
   {% if has_add_permission %}
-    {% url cl.opts|admin_urlname:'add' as add_url %}
-    <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
-      {% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}
-    </a>
+    <p class="margin-0 padding-0">
+      {% url cl.opts|admin_urlname:'add' as add_url %}
+      <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
+        {% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}
+      </a>
+    </p>  
   {% endif %}
 {% endblock %}

--- a/src/registrar/templates/admin/change_list_object_tools.html
+++ b/src/registrar/templates/admin/change_list_object_tools.html
@@ -1,0 +1,10 @@
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {% if has_add_permission %}
+    {% url cl.opts|admin_urlname:'add' as add_url %}
+    <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
+      {% blocktranslate with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktranslate %}
+    </a>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Ticket

Resolves #898
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Change in templates ul and li to p for Django admin object-tools links (ADD on change_list and HISTORY on change_form)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

This is the last bit of accessibility fix that we needed on django admin, according to Aaron.

This is a minimum viable fix (MVF?) that will satisfy requirement but needs some careful reviewing to make sure it's not dangerous. Form the Django templates, it seems like the initial implementation into an ordered list here was sloppy but I may be missing a repeater or iterator somewhere that'll cause the fix to have some unintended consequences under certain conditions.

Note: The rejected fixture is really tripping up Pa11y, so I commented it out. Maybe that bit belongs into its own separate PR?

Django original code:

https://github.com/django/django/blob/68a8996bdfce2d191decd7b1c1a2b9fdea8e4b2f/django/contrib/admin/templates/admin/change_form.html#L27-L34

https://github.com/django/django/blob/68a8996bdfce2d191decd7b1c1a2b9fdea8e4b2f/django/contrib/admin/templates/admin/change_list.html#L43C7-L49

https://github.com/django/django/blob/68a8996bdfce2d191decd7b1c1a2b9fdea8e4b2f/django/contrib/admin/templates/admin/change_form_object_tools.html

https://github.com/django/django/blob/68a8996bdfce2d191decd7b1c1a2b9fdea8e4b2f/django/contrib/admin/templates/admin/change_list_object_tools.html 

## Setup

Log into admin as a superuser and/or staff, navigate to list views and form views (applications listing then an individual application), inspect the markup on the grey buttons at the to right.

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots


![Screen Shot 2023-09-01 at 3 38 29 PM](https://github.com/cisagov/getgov/assets/107004823/fabc38ef-598b-4b47-83b7-1f59d15cf194)


![Screen Shot 2023-09-01 at 3 38 16 PM](https://github.com/cisagov/getgov/assets/107004823/752ca02a-3008-48f5-9cc1-b9379b8e4717)

