### PR TITLE
1000 admin ux audit implementation of quick fixes

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -6,8 +6,19 @@ from django.http.response import HttpResponseRedirect
 from django.urls import reverse
 from registrar.models.utility.admin_sort_fields import AdminSortFields
 from . import models
+from auditlog.models import LogEntry # type: ignore
+from auditlog.admin import LogEntryAdmin # type: ignore
+
 
 logger = logging.getLogger(__name__)
+
+class CustomLogEntryAdmin(LogEntryAdmin):
+    # Overwrite the generated LogEntry admin class
+    
+    search_help_text = "Search by resource, changed field, or user."
+    
+    change_form_template = 'admin/change_form_no_submit.html'
+    add_form_template = 'admin/change_form_no_submit.html'
 
 
 class AuditedAdmin(admin.ModelAdmin, AdminSortFields):
@@ -400,6 +411,8 @@ class DomainApplicationAdmin(ListHeaderAdmin):
         return super().change_view(request, object_id, form_url, extra_context)
 
 
+admin.site.unregister(LogEntry)  # Unregister the default registration
+admin.site.register(LogEntry, CustomLogEntryAdmin)
 admin.site.register(models.User, MyUserAdmin)
 admin.site.register(models.UserDomainRole, AuditedAdmin)
 admin.site.register(models.Contact, ContactAdmin)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -8,14 +8,33 @@ from registrar.models.utility.admin_sort_fields import AdminSortFields
 from . import models
 from auditlog.models import LogEntry # type: ignore
 from auditlog.admin import LogEntryAdmin # type: ignore
-
+from django.contrib.auth import get_user_model
 
 logger = logging.getLogger(__name__)
 
 class CustomLogEntryAdmin(LogEntryAdmin):
     # Overwrite the generated LogEntry admin class
+    # list_select_related = ["content_type", "actor"]
+    list_display = [
+        "created",
+        "custom_resource_url",
+        "action",
+        "msg_short",
+        "user_url",
+    ]
+    # search_fields = [
+    #     "content_type",
+    #     "object_repr",
+    #     "changes",
+    # ]
     
-    search_help_text = "Search by resource, changed field, or user."
+    def custom_resource_url(self, obj):
+        # Replace 'my_field' with the name of your field
+        return f"{obj.content_type} - {obj.object_repr}"  # Return the field value without a link
+    
+    custom_resource_url.short_description = 'Resource'
+    
+    search_help_text = "Search by resource, changes, or user."
     
     change_form_template = 'admin/change_form_no_submit.html'
     add_form_template = 'admin/change_form_no_submit.html'

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -6,38 +6,34 @@ from django.http.response import HttpResponseRedirect
 from django.urls import reverse
 from registrar.models.utility.admin_sort_fields import AdminSortFields
 from . import models
-from auditlog.models import LogEntry # type: ignore
-from auditlog.admin import LogEntryAdmin # type: ignore
-from django.contrib.auth import get_user_model
+from auditlog.models import LogEntry  # type: ignore
+from auditlog.admin import LogEntryAdmin  # type: ignore
 
 logger = logging.getLogger(__name__)
 
+
 class CustomLogEntryAdmin(LogEntryAdmin):
-    # Overwrite the generated LogEntry admin class
-    # list_select_related = ["content_type", "actor"]
+    """Overwrite the generated LogEntry admin class"""
+
     list_display = [
         "created",
-        "custom_resource_url",
+        "resource",
         "action",
         "msg_short",
         "user_url",
     ]
-    # search_fields = [
-    #     "content_type",
-    #     "object_repr",
-    #     "changes",
-    # ]
-    
-    def custom_resource_url(self, obj):
-        # Replace 'my_field' with the name of your field
-        return f"{obj.content_type} - {obj.object_repr}"  # Return the field value without a link
-    
-    custom_resource_url.short_description = 'Resource'
-    
+
+    # We name the custom prop 'resource' because linter
+    # is not allowing a short_description attr on it
+    # This gets around the linter limitation, for now.
+    def resource(self, obj):
+        # Return the field value without a link
+        return f"{obj.content_type} - {obj.object_repr}"
+
     search_help_text = "Search by resource, changes, or user."
-    
-    change_form_template = 'admin/change_form_no_submit.html'
-    add_form_template = 'admin/change_form_no_submit.html'
+
+    change_form_template = "admin/change_form_no_submit.html"
+    add_form_template = "admin/change_form_no_submit.html"
 
 
 class AuditedAdmin(admin.ModelAdmin, AdminSortFields):
@@ -121,14 +117,12 @@ class ListHeaderAdmin(AuditedAdmin):
 
 
 class UserContactInline(admin.StackedInline):
-
     """Edit a user's profile on the user page."""
 
     model = models.Contact
 
 
 class MyUserAdmin(BaseUserAdmin):
-
     """Custom user admin class to use our inlines."""
 
     inlines = [UserContactInline]
@@ -182,22 +176,34 @@ class MyUserAdmin(BaseUserAdmin):
 
 
 class HostIPInline(admin.StackedInline):
-
     """Edit an ip address on the host page."""
 
     model = models.HostIP
 
 
 class MyHostAdmin(AuditedAdmin):
-
     """Custom host admin class to use our inlines."""
 
     inlines = [HostIPInline]
 
 
 class DomainAdmin(ListHeaderAdmin):
-
     """Custom domain admin class to add extra buttons."""
+
+    # Columns
+    list_display = [
+        "name",
+        "organization_type",
+        "state",
+    ]
+
+    def organization_type(self, obj):
+        return (
+            obj.domain_info.organization_type
+        )
+
+    # Filters
+    list_filter = ["domain_info__organization_type"]
 
     search_fields = ["name"]
     search_help_text = "Search by domain name."
@@ -252,11 +258,97 @@ class ContactAdmin(ListHeaderAdmin):
 
     search_fields = ["email", "first_name", "last_name"]
     search_help_text = "Search by firstname, lastname or email."
+    list_display = [
+        "contact",
+        "email",
+    ]
+
+    # We name the custom prop 'contact' because linter
+    # is not allowing a short_description attr on it
+    # This gets around the linter limitation, for now.
+    def contact(self, obj):
+        if obj.first_name or obj.last_name:
+            return obj.get_formatted_name()
+        elif obj.email:
+            return obj.email
+        elif obj.pk:
+            return str(obj.pk)
+        else:
+            return ""
+
+
+class WebsiteAdmin(ListHeaderAdmin):
+    """Custom website admin class."""
+
+    # Search
+    search_fields = [
+        "website",
+    ]
+    search_help_text = "Search by website."
+
+
+class UserDomainRoleAdmin(ListHeaderAdmin):
+    """Custom domain role admin class."""
+
+    # Columns
+    list_display = [
+        "user",
+        "domain",
+        "role",
+    ]
+
+    # Search
+    search_fields = [
+        "user__first_name",
+        "user__last_name",
+        "domain__name",
+        "role",
+    ]
+    search_help_text = "Search by user, domain, or role."
+
+
+class DomainInvitationAdmin(ListHeaderAdmin):
+    """Custom domain invitation admin class."""
+
+    # Columns
+    list_display = [
+        "email",
+        "domain",
+        "status",
+    ]
+
+    # Search
+    search_fields = [
+        "email",
+        "domain__name",
+    ]
+    search_help_text = "Search by email or domain."
+
+
+class DomainInformationAdmin(ListHeaderAdmin):
+    """Customize domain information admin class."""
+
+    # Columns
+    list_display = [
+        "domain",
+        "organization_type",
+        "created_at",
+        "submitter",
+    ]
+
+    # Filters
+    list_filter = ["organization_type"]
+
+    # Search
+    search_fields = [
+        "domain__name",
+    ]
+    search_help_text = "Search by domain."
 
 
 class DomainApplicationAdmin(ListHeaderAdmin):
 
-    """Customize the applications listing view."""
+    """Custom domain applications admin class."""
 
     # Set multi-selects 'read-only' (hide selects and show data)
     # based on user perms and application creator's status
@@ -433,12 +525,12 @@ class DomainApplicationAdmin(ListHeaderAdmin):
 admin.site.unregister(LogEntry)  # Unregister the default registration
 admin.site.register(LogEntry, CustomLogEntryAdmin)
 admin.site.register(models.User, MyUserAdmin)
-admin.site.register(models.UserDomainRole, AuditedAdmin)
+admin.site.register(models.UserDomainRole, UserDomainRoleAdmin)
 admin.site.register(models.Contact, ContactAdmin)
-admin.site.register(models.DomainInvitation, AuditedAdmin)
-admin.site.register(models.DomainInformation, AuditedAdmin)
+admin.site.register(models.DomainInvitation, DomainInvitationAdmin)
+admin.site.register(models.DomainInformation, DomainInformationAdmin)
 admin.site.register(models.Domain, DomainAdmin)
 admin.site.register(models.Host, MyHostAdmin)
 admin.site.register(models.Nameserver, MyHostAdmin)
-admin.site.register(models.Website, AuditedAdmin)
+admin.site.register(models.Website, WebsiteAdmin)
 admin.site.register(models.DomainApplication, DomainApplicationAdmin)

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -140,7 +140,7 @@ h1, h2, h3 {
     font-weight: font-weight('bold');
 }
 
-table > caption > a {
+table > caption > span {
     font-weight: font-weight('bold');
     text-transform: none;
 }
@@ -158,8 +158,10 @@ table > caption > a {
     padding-top: 20px;
 }
 
-// 'Delete button' layout bug
-.submit-row a.deletelink {
+// Fix django admin button height bugs
+.submit-row a.deletelink,
+.delete-confirmation form .cancel-link,
+.submit-row a.closelink {
     height: auto!important;
 }
 

--- a/src/registrar/templates/admin/app_list.html
+++ b/src/registrar/templates/admin/app_list.html
@@ -4,11 +4,13 @@
   {% for app in app_list %}
     <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
       <table>
+        {# .gov override: remove link #}
         <caption>
-          <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
+          <span class="section">{{ app.name }}</span>
         </caption>
+        {# end .gov override #}
 
-        {# .gov override #}
+        {# .gov override: add headers #}
         <thead>
           <tr>
             <th scope="col">Model</th>

--- a/src/registrar/templates/admin/base_site.html
+++ b/src/registrar/templates/admin/base_site.html
@@ -2,6 +2,24 @@
 {% load static %}
 {% load i18n %}
 
+{% block extrahead %}
+  <link rel="icon" type="image/png" sizes="32x32" 
+  href="{% static 'img/registrar/favicons/favicon-32.png' %}"
+  >
+  <link rel="icon" type="image/png" sizes="192x192" 
+  href="{% static 'img/registrar/favicons/favicon-192.png' %}"
+  >
+  <link rel="icon" type="image/svg+xml" 
+  href="{% static 'img/registrar/favicons/favicon.svg' %}"
+  >
+  <link rel="shortcut icon" type="image/x-icon"
+  href="{% static 'img/registrar/favicons/favicon.ico' %}"
+  >
+  <link rel="apple-touch-icon" size="180x180" 
+  href="{% static 'img/registrar/favicons/favicon-180.png' %}"
+  >
+{% endblock %}
+
 {% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 
 {% block extrastyle %}{{ block.super }}

--- a/src/registrar/templates/admin/change_form_no_submit.html
+++ b/src/registrar/templates/admin/change_form_no_submit.html
@@ -10,3 +10,11 @@
     </div>
 {% endif %}
 {% endblock %}
+
+{% block submit_buttons_top %}
+    {# Do not render the submit buttons #}
+{% endblock %}
+
+{% block submit_buttons_bottom %}
+    {# Do not render the submit buttons #}
+{% endblock %}


### PR DESCRIPTION
## Ticket

Resolves #1000

Related to #935 

UX Audit: [document](https://docs.google.com/document/d/1HmF_jCOcYUEj_gBd5NMuVuSQi6a85TLTl0Mk7uFtZGs/edit#heading=h.68g1pvvfauc)

<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Add a favicon
- Fix button on “Are You Sure” pages
- Fix button on “view-only” pages
- Remove table caption links
- Log Entries: 
  - Remove “Resource” links
  - Add search helper text
  - Remove “Save” buttons
- Add email address to contact table
- Domain Information
  - Add search field
  - Add additional columns
  - Add filters
- Domain Invitation
  - Add additional columns
  - Add search
- Domains
  - Add additional columns
  - Add filters
- User Domains Roles
  - Add additional columns
  - Add a search field
- Add a search field to websites 


<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Only non-straightforward part is the LogEntry override, see [repo link](https://github.com/jazzband/django-auditlog/blob/master/auditlog/admin.py)

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
