### PR TITLE
1028 - Check Domain availability via epp - Testing

### DIFF
--- a/src/epplibwrapper/__init__.py
+++ b/src/epplibwrapper/__init__.py
@@ -45,6 +45,7 @@ try:
     from .client import CLIENT, commands
     from .errors import RegistryError, ErrorCode
     from epplib.models import common
+    from epplib import responses
 except ImportError:
     pass
 
@@ -52,6 +53,7 @@ __all__ = [
     "CLIENT",
     "commands",
     "common",
+    "responses",
     "ErrorCode",
     "RegistryError",
 ]

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -278,10 +278,13 @@ class TestDomainAvailable(MockEppLib):
             Validate CheckDomain command is called
             Validate response given mock
         """
+
         def side_effect(_request, cleaned):
             return MagicMock(
                 res_data=[
-                    responses.check.CheckDomainResultData(name='available.gov', avail=True, reason=None)
+                    responses.check.CheckDomainResultData(
+                        name="available.gov", avail=True, reason=None
+                    )
                 ],
             )
 
@@ -294,9 +297,7 @@ class TestDomainAvailable(MockEppLib):
             [
                 call(
                     commands.CheckDomain(
-                        [
-                            "available.gov"
-                        ],
+                        ["available.gov"],
                     ),
                     cleaned=True,
                 )
@@ -314,13 +315,12 @@ class TestDomainAvailable(MockEppLib):
             Validate CheckDomain command is called
             Validate response given mock
         """
+
         def side_effect(_request, cleaned):
             return MagicMock(
                 res_data=[
                     responses.check.CheckDomainResultData(
-                        name='unavailable.gov',
-                        avail=False,
-                        reason="In Use"
+                        name="unavailable.gov", avail=False, reason="In Use"
                     )
                 ],
             )
@@ -334,9 +334,7 @@ class TestDomainAvailable(MockEppLib):
             [
                 call(
                     commands.CheckDomain(
-                        [
-                            "unavailable.gov"
-                        ],
+                        ["unavailable.gov"],
                     ),
                     cleaned=True,
                 )
@@ -358,17 +356,18 @@ class TestDomainAvailable(MockEppLib):
     def test_domain_available_unsuccessful(self):
         """
         Scenario: Testing behavior when registry raises a RegistryError
-        
+
             Validate RegistryError is raised
         """
+
         def side_effect(_request, cleaned):
             raise RegistryError(code=ErrorCode.COMMAND_SYNTAX_ERROR)
-        
+
         patcher = patch("registrar.models.domain.registry.send")
         mocked_send = patcher.start()
         mocked_send.side_effect = side_effect
 
-        with self.assertRaises(RegistryError) as err:
+        with self.assertRaises(RegistryError):
             Domain.available("raises-error.gov")
         patcher.stop()
 


### PR DESCRIPTION
## Ticket

Resolves #1028 

## Changes

- No code changes necessary on this one upon review of existing code in models/domain.py
- TestDomainAvailable tests added to test_models_domain.py

## Context for reviewers

Manually verified and thoroughly tested EPP CheckDomain function in sandbox, and available() classmethod
in models/domain.py.  Determined that no code changes were necessary for models/domain.py

For review in this case are the test cases in TestAvailable.  I assume this is a code review only.

For reference, the test cases are:
  test_domain_available
  test_domain_unavailable
  test_domain_available_with_value_error
  test_domain_available_unsuccessful

If you pull the branch and test locally:
docker-compose exec app ./manage.py test registrar.tests.test_models_domain.TestDomainAvailable

## Setup

I do not believe any additional setup is necessary for review on this one

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

No user-facing changes, no screenshots supplied for review
