### PR TITLE
Update issue template to add A/C and clarity

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -20,6 +20,7 @@ body:
     attributes:
       label: Acceptance criteria
       description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists#creating-task-lists) if appropriate."
+      placeholder: "- [ ] The button does the thing."
   - type: textarea
     id: links-to-other-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Issue description and context
       description: |
-        Describe the issue so that someone who wasn't present for its discovery can understand the problem and why it matters. Use full sentences, plain language, and good [formatting](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax). Share desired outcomes or potential next steps. Images or links to other content/context (like documents or Slack discussion) are welcome.
+        Describe the issue so that someone who wasn't present for its discovery can understand the problem and why it matters. Use full sentences, plain language, and good [formatting](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax). Share desired outcomes or potential next steps. Images or links to other content/context (like documents or Slack discussions) are welcome.
     validations:
       required: true
   - type: textarea
@@ -25,8 +25,8 @@ body:
     attributes:
       label: Links to other issues
       description: |
-        Add the issue number of other issues this relates to and how (blocks, is blocked by, relates to).
-      placeholder: Relates to...
+        "Add the issue #number of other issues this relates to and how (e.g., 🚧 Blocks, ⛔️ Is blocked by, 🔄 Relates to)."
+      placeholder: 🔄 Relates to... 
   - type: markdown
     id: note
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -26,10 +26,9 @@ body:
       label: Links to other issues
       description: |
         Add the issue number of other issues this relates to and how (blocks, is blocked by, relates to).
-      placeholder: relates to #123
-  - type: textarea
+      placeholder: Relates to...
+  - type: markdown
     id: note
     attributes:
-      label: Note
-      description: |
-        We may edit this issue's text to document our understanding and clarify the product work.
+      value: |
+        > We may edit this issue's text to document our understanding and clarify the product work.

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: Links to other issues
       description: |
-        "Add the issue #number of other issues this relates to and how (e.g., 🚧 Blocks, ⛔️ Is blocked by, 🔄 Relates to)."
+        Add the issue #number of other issues this relates to and how (e.g., 🚧 Blocks, ⛔️ Is blocked by, 🔄 Relates to).
       placeholder: 🔄 Relates to... 
   - type: markdown
     id: note

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Acceptance criteria
       description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists#creating-task-lists) if appropriate."
-      value: - [ ]
+      placeholder: - [ ]
   - type: textarea
     id: links-to-other-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -1,32 +1,36 @@
 name: Issue
-description: Capture uncategorized work or content
+description: Describe an idea, feature, content, or non-bug finding
 
 body:
   - type: markdown
-    id: help
+    id: title-help
     attributes:
       value: |
         > Titles should be short, descriptive, and compelling.
   - type: textarea
-    id: issue
+    id: issue-description
     attributes:
       label: Issue description and context
       description: |
-        Describe the issue so that someone who wasn't present for its discovery can understand the problem and why it matters. Use full sentences, plain language, and good [formatting](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax – links and images welcome! Share desired outcomes or potential next steps.
+        Describe the issue so that someone who wasn't present for its discovery can understand the problem and why it matters. Use full sentences, plain language, and good [formatting](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax). Share desired outcomes or potential next steps. Images or links to other content/context (like documents or Slack discussion) are welcome.
     validations:
       required: true
   - type: textarea
     id: acceptance-criteria
     attributes:
       label: Acceptance criteria
-      description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a checklist."
+      description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists#creating-task-lists) if appropriate."
+      value: - [ ]
   - type: textarea
-    id: issue-links
+    id: links-to-other-issues
     attributes:
-      label: Other issues
+      label: Links to other issues
       description: |
-        Add the issue number of other issues this relates to and how.
-        
-        Example:
-        - 🚧 Blocks/is blocked by #123
-        - 🔄 Relates to #234
+        Add the issue number of other issues this relates to and how (blocks, is blocked by, relates to).
+      placeholder: relates to #123
+  - type: textarea
+    id: note
+    attributes:
+      label: Note
+      description: |
+        We may edit this issue's text to document our understanding and clarify the product work.

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -20,7 +20,6 @@ body:
     attributes:
       label: Acceptance criteria
       description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists#creating-task-lists) if appropriate."
-      placeholder: - [ ]
   - type: textarea
     id: links-to-other-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -6,29 +6,27 @@ body:
     id: help
     attributes:
       value: |
-        > **Note**
-        > GitHub Issues use [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for formatting.
+        > Titles should be short, descriptive, and compelling.
   - type: textarea
     id: issue
     attributes:
-      label: Issue Description
+      label: Issue description and context
       description: |
-        Describe the issue you are adding or content you are suggesting.
-        Share any next steps that should be taken our outcomes that would be beneficial.
+        Describe the issue so that someone who wasn't present for its discovery can understand the problem and why it matters. Use full sentences, plain language, and good [formatting](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax – links and images welcome! Share desired outcomes or potential next steps.
     validations:
       required: true
   - type: textarea
-    id: additional-context
+    id: acceptance-criteria
     attributes:
-      label: Additional Context (optional)
-      description: "Include additional references (screenshots, design links, documentation, etc.) that are relevant"
+      label: Acceptance criteria
+      description: "If known, share 1-3 statements that would need to be true for this issue to be considered resolved. Use a checklist."
   - type: textarea
     id: issue-links
     attributes:
-      label: Issue Links
+      label: Other issues
       description: |
-        What other issues does this story relate to and how?
+        Add the issue number of other issues this relates to and how.
         
         Example:
-        - 🚧 Blocked by: #123
-        - 🔄 Relates to: #234
+        - 🚧 Blocks/is blocked by #123
+        - 🔄 Relates to #234


### PR DESCRIPTION
This PR updates our `issue` issue template to add acceptance criteria and attempts clearer language.

## Context for reviewers

* It should be easy for our team and other interested people to submit issues to this repo. Though we should avoid overprescription, including common fields and reminders makes the work of creation better for the creators. 
* There is also a `story` issue template. Perhaps we should cut that and include relevant content here? It seems like we could recommend an `issue`-writer start with a user story and drop the other template.
* We currently use issues to determine ground truth for feature development and regularly edit issues to improve them – even ones other people submitted. That's not a common approach, and someone who wasn't expecting it might be offended by it. Should we give a heads up in our template and say e.g., "Issues may be revised by the product team to improve our understanding."?