### PR TITLE
Allow connections from manage.get.gov

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -581,7 +581,7 @@ ALLOWED_HOSTS = [
     "getgov-bl.app.cloud.gov",
     "getgov-rjm.app.cloud.gov",
     "getgov-dk.app.cloud.gov",
-    "get.gov",
+    "manage.get.gov",
 ]
 
 # Extend ALLOWED_HOSTS.


### PR DESCRIPTION
# Allow connections from manage.get.gov

We are making our application run on the manage.get.gov domain so we need to add that to `ALLOWED_HOSTS`. Additionally, we don't want to allow connections from just `get.gov` because that will be our documentation site.

## Changes

Change `get.gov` to `manage.get.gov` in `ALLOWED_HOSTS`.