### PR TITLE
Use manage.get.gov as the BASE_URL

### DIFF
--- a/ops/manifests/manifest-stable.yaml
+++ b/ops/manifests/manifest-stable.yaml
@@ -18,7 +18,7 @@ applications:
     # Tell Django where to find its configuration
     DJANGO_SETTINGS_MODULE: registrar.config.settings
     # Tell Django where it is being hosted
-    DJANGO_BASE_URL: https://getgov-stable.app.cloud.gov
+    DJANGO_BASE_URL: https://manage.get.gov
     # Tell Django how much stuff to log
     DJANGO_LOG_LEVEL: INFO
     # default public site location


### PR DESCRIPTION
## Configure Django to run as manage.get.gov

We want our Django application on stable to respond with links as `manage.get.gov` now.