### PR TITLE
Ticket #1810: Fix 500 error showing test site banner

### DIFF
--- a/src/djangooidc/views.py
+++ b/src/djangooidc/views.py
@@ -50,13 +50,13 @@ def error_page(request, error):
     """Display a sensible message and log the error."""
     logger.error(error)
     if isinstance(error, o_e.AuthenticationFailed):
-        context={
+        context = {
             "friendly_message": error.friendly_message,
             "log_identifier": error.locator,
         }
         return custom_401_error_view(request, context)
     if isinstance(error, o_e.InternalError):
-        context={
+        context = {
             "friendly_message": error.friendly_message,
             "log_identifier": error.locator,
         }

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -3,7 +3,7 @@
 For more information see:
     https://docs.djangoproject.com/en/4.0/topics/http/urls/
 """
-from django.conf.urls import handler500
+
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView
@@ -151,6 +151,14 @@ urlpatterns = [
 
 # Djangooidc strips out context data from that context, so we define a custom error
 # view through this method.
+# If Djangooidc is left to its own devices and uses reverse directly,
+# then both context and session information will be obliterated due to:
+
+# a) Djangooidc being out of scope for context_processors
+# b) Potential cyclical import errors restricting what kind of data is passable.
+
+# Rather than dealing with that, we keep everything centralized in one location.
+# This way, we can share a view for djangooidc, and other pages as we see fit.
 handler500 = "registrar.views.utility.error_views.custom_500_error_view"
 
 # we normally would guard these with `if settings.DEBUG` but tests run with

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -325,7 +325,6 @@ class Domain(TimeStampedModel, DomainHelper):
         Subordinate hosts (something.your-domain.gov) MUST have IP addresses,
         while non-subordinate hosts MUST NOT.
         """
-        raise ValueError("test")
         try:
             # attempt to retrieve hosts from registry and store in cache and db
             hosts = self._get_property("hosts")

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -6,7 +6,7 @@ from registrar.models.domain import Domain
 from registrar.models.user_domain_role import UserDomainRole
 from registrar.views.domain import DomainNameserversView
 
-from .common import MockEppLib, less_console_noise  # type: ignore
+from .common import MockEppLib  # type: ignore
 from unittest.mock import patch
 from django.urls import reverse
 
@@ -135,4 +135,3 @@ class TestEnvironmentVariablesEffects(TestCase):
                 self.assertEqual(contact_page_500.status_code, 500)
 
                 self.assertNotContains(contact_page_500, "You are on a test site.")
-

--- a/src/registrar/views/utility/error_views.py
+++ b/src/registrar/views/utility/error_views.py
@@ -1,5 +1,20 @@
-"""Custom views that allow for error view customization"""
+"""
+Custom views that allow for error view customization.
+
+Used as a general handler for 500 errors both coming from the registrar app, but
+also the djangooidc app.
+
+If Djangooidc is left to its own devices and uses reverse directly,
+then both context and session information will be obliterated due to:
+
+a) Djangooidc being out of scope for context_processors
+b) Potential cyclical import errors restricting what kind of data is passable.
+
+Rather than dealing with that, we keep everything centralized in one location.
+"""
+
 from django.shortcuts import render
+
 
 def custom_500_error_view(request, context=None):
     """Used to redirect 500 errors to a custom view"""
@@ -7,6 +22,7 @@ def custom_500_error_view(request, context=None):
         return render(request, "500.html", status=500)
     else:
         return render(request, "500.html", context=context, status=500)
+
 
 def custom_401_error_view(request, context=None):
     """Used to redirect 401 errors to a custom view"""

--- a/src/registrar/views/utility/permission_views.py
+++ b/src/registrar/views/utility/permission_views.py
@@ -2,7 +2,6 @@
 
 import abc  # abstract base class
 
-from django.conf import settings
 from django.views.generic import DetailView, DeleteView, TemplateView
 from registrar.models import Domain, DomainRequest, DomainInvitation
 from registrar.models.user_domain_role import UserDomainRole


### PR DESCRIPTION
## Ticket

Resolves #1810
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Modified dispatch on `permission_views.py` to include "IS_PRODUCTION" in session data
- Added a temporary change to nameservers such that it always throws a valueerror for testing purposes (will be removed before merge)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
This PR addresses a bug where the purple test banner would display on production when a 500 error would display.
It also addresses the opposite of that, where the banner would _disappear_ when a 500 error would display on non-prod environments.

This bug would occur because the request's session (for exception pages) wouldn't "carry over" information, as would otherwise happen on other views. I believe this is due to the architecture in `djangooidc/views.py`. This may be a candidate for future refactoring. If we decide that, this should not occur in this ticket given the scope of changes that would incur. 

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup
This PR needs to be tested on a sandbox of your choosing. Due to the nature of the bug (it impacts both IS_PRODUCTION = False and IS_PRODUCTION = True), you need to do a cf push of both of these values and test them.

1. On the sandbox of your choosing, cf push the contents of this branch to your sandbox. Do not make any alterations at this point.
2. Navigate to the sandbox of your choosing. Note the purple "Attention: You are on a test site." banner at the top of the page.
3. On any "ready", "unknown", or "dns needed" domain, click Manage domain > DNS > Name servers > (name servers button). A 500 error will occur. **This banner should still be present**
4. With your preferred code editor, change the `IS_PRODUCTION` flag in `settings.py` on line 99 to `IS_PRODUCTION = TRUE`
5. Stage your changes, and repeat steps 2-3. Except now, the banner should NOT exist in both scenarios
<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
