### PR TITLE
Revert "Ticket #2158: Use biometric auth instead of IAL2"

### DIFF
--- a/src/djangooidc/tests/test_views.py
+++ b/src/djangooidc/tests/test_views.py
@@ -397,31 +397,25 @@ class ViewsTest(TestCase):
         """Invoke login_callback passing it a request when _requires_step_up_auth returns True
         and assert that session is updated and create_authn_request (mock) is called."""
         with less_console_noise():
+            # MOCK
+            # Configure the mock to return an expected value for get_step_up_acr_value
+            mock_client.return_value.get_step_up_acr_value.return_value = "step_up_acr_value"
             # Create a mock request
             request = self.factory.get("/some-url")
             request.session = {"acr_value": ""}
-
             # Ensure that the CLIENT instance used in login_callback is the mock
             # patch _requires_step_up_auth to return True
             with patch("djangooidc.views._requires_step_up_auth", return_value=True), patch(
-                "djangooidc.views.CLIENT.create_authn_request"
+                "djangooidc.views.CLIENT.create_authn_request", return_value=MagicMock()
             ) as mock_create_authn_request:
-                with patch("djangooidc.views.CLIENT.get_vtm_value") as mock_get_vtm_value, patch(
-                    "djangooidc.views.CLIENT.get_vtr_value"
-                ) as mock_get_vtr_value:
-                    mock_get_vtm_value.return_value = "test_vtm"
-                    mock_get_vtr_value.return_value = "test_vtr"
-                    # TEST
-                    # test the login callback
-                    login_callback(request)
-
+                # TEST
+                # test the login callback
+                login_callback(request)
             # ASSERTIONS
-            # create_authn_request only gets called when _requires_step_up_auth is True.
-            # The acr_value should be blank here
-            self.assertEqual(request.session["acr_value"], "")
-            self.assertEqual(request.session["vtm"], "test_vtm")
-            self.assertEqual(request.session["vtr"], "test_vtr")
-
+            # create_authn_request only gets called when _requires_step_up_auth is True
+            # and it changes this acr_value in request.session
+            # Assert that acr_value is no longer empty string
+            self.assertNotEqual(request.session["acr_value"], "")
             # And create_authn_request was called again
             mock_create_authn_request.assert_called_once()
 

--- a/src/djangooidc/views.py
+++ b/src/djangooidc/views.py
@@ -91,21 +91,12 @@ def login_callback(request):
             _initialize_client()
         query = parse_qs(request.GET.urlencode())
         userinfo = CLIENT.callback(query, request.session)
-
         # test for need for identity verification and if it is satisfied
-        # if not satisfied, redirect user to login requiring biometric auth
-
-        # Tests for the presence of the vtm/vtr values in the userinfo object.
-        # If they are there, then we can set a flag in our session for tracking purposes.
-        needs_step_up_auth = _requires_step_up_auth(userinfo)
-        request.session["needs_step_up_auth"] = needs_step_up_auth
-
-        # Return a redirect request to a new auth url that does biometric validation
-        if needs_step_up_auth:
-            request.session["vtm"] = CLIENT.get_vtm_value()
-            request.session["vtr"] = CLIENT.get_vtr_value()
-            return CLIENT.create_authn_request(request.session, do_step_up_auth=True)
-
+        # if not satisfied, redirect user to login with stepped up acr_value
+        if _requires_step_up_auth(userinfo):
+            # add acr_value to request.session
+            request.session["acr_value"] = CLIENT.get_step_up_acr_value()
+            return CLIENT.create_authn_request(request.session)
         user = authenticate(request=request, **userinfo)
         if user:
 
@@ -147,27 +138,14 @@ def login_callback(request):
         return error_page(request, err)
 
 
-def _requires_step_up_auth(userinfo) -> bool:
-    """
-    Checks for the presence of the key 'vtm' and 'vtr' in the provided `userinfo` object.
-
-    If they are not found, then we call `User.needs_identity_verification()`.
-
-    Args:
-        userinfo (dict): A dictionary of data from the returned user object.
-
-    Return Conditions:
-        If the provided user does not exist in any tables which would preclude them from doing
-        biometric authentication, then we return True. Otherwise, we return False.
-
-        Alternatively, if 'vtm' and 'vtr' already exist on `userinfo`, then we return False.
-
-    """
+def _requires_step_up_auth(userinfo):
+    """if User.needs_identity_verification and step_up_acr_value not in
+    ial returned from callback, return True"""
+    step_up_acr_value = CLIENT.get_step_up_acr_value()
+    acr_value = userinfo.get("ial", "")
     uuid = userinfo.get("sub", "")
     email = userinfo.get("email", "")
-    # This value is returned after successful auth
-    user_verified = userinfo.get("vot", "")
-    if not userinfo.get("vtm") or not userinfo.get("vtr") or not user_verified:
+    if acr_value != step_up_acr_value:
         # The acr of this attempt is not at the highest level
         # so check if the user needs the higher level
         return User.needs_identity_verification(email, uuid)

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -562,11 +562,7 @@ OIDC_PROVIDERS = {
             "scope": ["email", "profile:name", "phone"],
             "user_info_request": ["email", "first_name", "last_name", "phone"],
             "acr_value": "http://idmanagement.gov/ns/assurance/ial/1",
-            # "P1" is the current IdV option; "Pb" stands for 'biometric'
-            "vtr": ["Pb", "P1"],
-            # The url that biometric authentication takes place at.
-            # A similar analog is the url for acr_value.
-            "vtm": "https://developer.login.gov/vot-trust-framework",
+            "step_up_acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
         },
         "client_registration": {
             "client_id": "cisa_dotgov_registrar",
@@ -584,11 +580,7 @@ OIDC_PROVIDERS = {
             "scope": ["email", "profile:name", "phone"],
             "user_info_request": ["email", "first_name", "last_name", "phone"],
             "acr_value": "http://idmanagement.gov/ns/assurance/ial/1",
-            # "P1" is the current IdV option; "Pb" stands for 'biometric'
-            "vtr": ["Pb", "P1"],
-            # The url that biometric authentication takes place at.
-            # A similar analog is the url for acr_value.
-            "vtm": "https://developer.login.gov/vot-trust-framework",
+            "step_up_acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
         },
         "client_registration": {
             "client_id": ("urn:gov:cisa:openidconnect.profiles:sp:sso:cisa:dotgov_registrar"),


### PR DESCRIPTION
Reverts cisagov/manage.get.gov#2181

This ticket is not quite ready to merge to stable yet. For now lets put it on the back burner and revert these changes.