### PR TITLE
Fix docker-compose race condition: ./manage.py load is ran before a cachetable can be created

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -67,8 +67,8 @@ services:
     # command: "python"
     command: >
       bash -c " python manage.py migrate &&
-      python manage.py load &&
       python manage.py createcachetable &&
+      python manage.py load &&
       python manage.py runserver 0.0.0.0:8080"
 
   db:


### PR DESCRIPTION
## Ticket

None
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- This PR changes the order of our docker-compose.yaml commands locally, such that we run cachetable first, THEN we run load
<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
Recently, after updating my docker, I have been running into a race condition locally wherein the "load" command starts running before a cache table is created - causing a migration issue.

This tends to happen sporadically, but it doesn't hurt to fix the load order of these anyway.
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Screenshots
![image](https://github.com/cisagov/manage.get.gov/assets/141044360/3da647d0-ac58-4f7e-9eed-a212b1b49d54)

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
