### PR TITLE
#3730: Remove references svgs that don't exist

### DIFF
--- a/src/registrar/templates/401.html
+++ b/src/registrar/templates/401.html
@@ -30,13 +30,6 @@
         <p>{% translate "Please include it if you contact us." %}</p>
       {% endif %}
     </div>
-    
-    <div class="tablet:grid-col-4">
-      <img 
-         src="{% static 'img/registrar/dotgov_401_illo.svg' %}"
-         alt=""
-      />
-    </div>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/403.html
+++ b/src/registrar/templates/403.html
@@ -35,12 +35,6 @@
         <p>{% translate "Please include it if you contact us." %}</p>
       {% endif %}
     </div>
-    <div class="tablet:grid-col-4">
-      <img 
-         src="{% static 'img/registrar/dotgov_401_illo.svg' %}"
-         alt=""
-      />
-    </div>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/404.html
+++ b/src/registrar/templates/404.html
@@ -18,15 +18,6 @@
       <p> Try going to the <a href="/">homepage</a>. If you can’t find what you’re looking for, <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">contact us</a>.
       </p>
     </div>
-
-    <div class="tablet:grid-col-4">
-      <img 
-         src="{% static 'img/registrar/dotgov_404_illo.svg' %}"
-         alt=""
-      />
-    </div>
   </div>
-
-
 </main>
 {% endblock %}

--- a/src/registrar/templates/500.html
+++ b/src/registrar/templates/500.html
@@ -29,12 +29,6 @@
       <p>{% translate "Please include it if you contact us." %}</p>
       {% endif %}
     </div>
-    <div class="tablet:grid-col-4 flex-align-self-end">
-      <img 
-         src="{%static 'img/registrar/dotgov_500_illo.svg' %}"
-         alt=""
-      />
-    </div>
   </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
## Ticket

Resolves #3730 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Removed references to svgs that don't exist so we don't get 404s when trying to load them


## Context for reviewers

The goal of this ticket was to clean up logs but to make sure it was timeboxed.  I attempted to reduce the logs for PermissionDenied but it was tricky to preserve the django default of handling permission denied and not printing the stacktrace.  If there's a strong case for breaking the pattern using default exception handling we can probably add middleware that uses `process_exception`

I didn't get around to inspect the epplib warning


## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
