### PR TITLE
#4399: Remove dns_prototype_flag from WaffleFlags

### DIFF
--- a/src/registrar/migrations/0171_remove_waffle_flags.py
+++ b/src/registrar/migrations/0171_remove_waffle_flags.py
@@ -1,0 +1,32 @@
+# Copied from 0154_remove_waffle_flags.py
+# Remove references to outdated flag name dns_prototype_flag which is now renamed to dns_hosting
+
+from django.db import migrations, models
+
+
+def remove_old_flags(apps, schema_editor):
+    """
+    Forward migration to delete the specified WaffleFlag objects
+    """
+
+    WaffleFlag = apps.get_model("registrar", "WaffleFlag")
+
+    try:
+        WaffleFlag.objects.get(name="dns_prototype_flag").delete()
+    except WaffleFlag.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("registrar", "0170_dnsrecord_dns_zone_dnszone_vendor_dns_zone_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_old_flags,
+            reverse_code=migrations.RunPython.noop,
+            atomic=True,
+        ),
+    ]


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4399 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Add migration to remove dns_prototype_flag from waffle flags

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
We previously used and added the `dns_prototype_flag` as a feature flag for DNS hosting. This flag has now been renamed to `dns_hosting` but we want to remove the outdated name from any of the waffle flag tables in our environments.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->


**Option 1: Local**
1. For the most convenient setup, I recommend running a local container from the `main` branch. This starts a container with all migrations excluding the one in this PR that removes the outdated waffle flag.
2. On /admin, add a waffle flag named `dns_prototype_flag` to the Waffle flags table.
3. Switch to this branch `es/4399-remove-outdated-dns-flag`.
4. You can verify your current branch has the new migration using `docker compose exec app ./manage.py showmigrations`. The migration `0171_remove_waffle_flags` should display unchecked.
``` 
...
[X] 0170_dnsrecord_dns_zone_dnszone_vendor_dns_zone_and_more
[ ] 0171_remove_waffle_flags
```
 5. Run this migration with the command `docker compose exec app ./manage.py migrate.`
 6. Go to /admin. The `dns_prototype_flag` should be deleted from the Waffle flags table.


**Option 2: Sandbox environment**
Alternatively, you can test this on any sandbox that still has the `dns_prototype_flag` waffle flag.
1. Deploy this branch to your sandbox of choice. This sandbox should have a `dns_prototype_flag` waffle flag.
2. On your CLI, ssh into your sandbox and run migrations.
```
cf ssh getgov-[environment]
/tmp/lifecycle/shell
./manage.py migrate
```
3. On /admin, you should see the `dns_prototype_flag` is now deleted.



## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
