### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Infrastructure as a (public) service
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cisagov/manage.get.gov)
 
 The .gov domain helps U.S.-based government organizations gain public trust by being easily recognized online. This repo contains the code for the new .gov registrar – where governments request and manage domains – and other artifacts about our product strategy and research.
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cisagov/manage.get.gov) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.