### PR TITLE
#4752: Pickle test run CI error fixes

### DIFF
--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -866,8 +866,9 @@ class DomainDNSRecordForm(forms.ModelForm):
         ),
     )
 
-    ttl = forms.ChoiceField(
+    ttl = forms.TypedChoiceField(
         label="TTL",
+        coerce=int,
         choices=[
             (60, "1 minute"),
             (300, "5 minutes"),

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -19,7 +19,7 @@ from registrar.models import (
 from registrar.utility.constants import CURRENT_DNS_VENDOR
 from django.db import transaction
 from registrar.services.utility.dns_helper import make_dns_account_name
-from httpx import Client
+from httpx import Client, HTTPStatusError
 
 logger = logging.getLogger(__name__)
 
@@ -165,17 +165,17 @@ class DnsHostService:
         try:
             vendor_record_data = self.dns_vendor_service.create_dns_record(x_zone_id, form_record_data)
             logger.info(f"Created DNS record of type {vendor_record_data['result'].get('type')}")
-        except APIError as e:
+        except (APIError, HTTPStatusError) as e:
             logger.error(f"Error creating DNS record: {str(e)}")
-            raise
+            raise APIError(str(e)) from e
 
         # Create and save dns record in registrar db
         try:
-            self.create_db_record(x_zone_id, vendor_record_data)
+            dns_record = self.create_db_record(x_zone_id, vendor_record_data)
         except Exception as e:
             logger.error(f"Failed to save record {form_record_data} in database: {str(e)}.")
             raise
-        return vendor_record_data
+        return {**vendor_record_data, "dns_record": dns_record}
 
     def update_and_save_record(self, x_zone_id, x_record_id, form_record_data) -> dict:
         """Calls update method of vendor service to update a DNS record"""
@@ -185,9 +185,9 @@ class DnsHostService:
             record_name = vendor_record_data["result"].get("name")
             logger.info(f"Successfully updated record {record_name}.")
 
-        except APIError as e:
+        except (APIError, HTTPStatusError) as e:
             logger.error(f"DNS setup failed to update record {record_name}: {str(e)}")
-            raise
+            raise APIError(str(e)) from e
 
         # Update and save dns record in registrar db
         try:
@@ -374,6 +374,7 @@ class DnsHostService:
         except Exception as e:
             logger.error(f"Failed to create and save record to database: {str(e)}.")
             raise
+        return dns_record
 
     def update_db_record(self, x_zone_id, x_record_id, vendor_record_data):
         record_data = vendor_record_data["result"]

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -6,7 +6,8 @@ from waffle.testutils import override_flag
 from django.conf import settings
 
 from registrar.utility.enums import DNSRecordTypes
-from registrar.tests.helpers.dns_data_generator import create_initial_dns_setup, delete_all_dns_data
+from registrar.utility.errors import APIError
+from registrar.tests.helpers.dns_data_generator import create_initial_dns_setup, create_dns_record, delete_all_dns_data
 
 from registrar.tests.test_views import TestWithUser
 from api.tests.common import less_console_noise_decorator
@@ -88,7 +89,14 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
                     svc = MockSvc.return_value
                     svc.register_nameservers.return_value = None
                     svc.get_x_zone_id_if_zone_exists.return_value = ("zone-123", True)
-                    svc.create_and_save_record.return_value = {"result": mock_record}
+                    dns_record = create_dns_record(
+                        self.dns_zone,
+                        record_name=data["name"],
+                        record_type=data["type"],
+                        record_content=data["content"],
+                        ttl=data["ttl"],
+                    )
+                    svc.create_and_save_record.return_value = {"result": mock_record, "dns_record": dns_record}
 
                     page = self.app.get(self._url(), status=200)
                     record_form = page.forms[0]
@@ -106,6 +114,42 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
 
                     # User visible success message snippet
                     self.assertIn(f'{data["type"]} record for {data["name"]}', response.text)
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_post_valid_form_api_error_returns_200_with_error_message(self):
+        """Regression test for when create_and_save_record raises APIError after a valid
+        form submission, the view must return 200 with an error message rather than crashing
+        with TypeError from self.dns_record["form"] = ... when self.dns_record is None."""
+        data = self.RECORD_TEST_CASES[0]
+
+        with patch("registrar.views.domain.DnsHostService") as MockSvc:
+            svc = MockSvc.return_value
+            svc.get_x_zone_id_if_zone_exists.return_value = ("zone-123", True)
+            svc.create_and_save_record.side_effect = APIError("Vendor rejected the record")
+
+            page = self.app.get(self._url(), status=200)
+            record_form = page.forms[0]
+
+            record_form["type"] = data["type"]
+            record_form["name"] = data["name"]
+            record_form["content"] = data["content"]
+            record_form["ttl"] = data["ttl"]
+
+            session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+            self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+            response = record_form.submit()
+
+            # Must not crash — previously raised TypeError: 'NoneType' object does not support item assignment
+            self.assertEqual(response.status_code, 200)
+
+            # Error path: only messagesRefresh triggered, not recordSubmitSuccess
+            # (messages.error stores in session; HX-TRIGGER tells the frontend to fetch them)
+            hx_trigger = response.headers.get("HX-TRIGGER", "")
+            self.assertNotIn("recordSubmitSuccess", hx_trigger)
+
+            # No new record row rendered because dns_record=None was passed to the template
+            self.assertNotIn(f'{data["type"]} record for {data["name"]}', response.text)
 
     @override_flag("dns_hosting", active=True)
     @less_console_noise_decorator

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -929,8 +929,8 @@ class DomainDNSRecordsView(DomainFormBaseView):
                 form_record_data,
             )
 
-            self.dns_record = record_response["result"]
-            dns_name = self.dns_record["name"]
+            self.dns_record = record_response.get("dns_record")
+            dns_name = self.dns_record.name if self.dns_record else ""
 
             messages.success(request, f"DNS A record '{dns_name}' created successfully.")
             context_dns_record.set(self.dns_record)
@@ -938,14 +938,19 @@ class DomainDNSRecordsView(DomainFormBaseView):
         except APIError as e:
             logger.error(f"DNS record creation failed, API error in view {e}")
             messages.error(request, "Failed to create DNS record.")
-            self.dns_record = None
+            return TemplateResponse(
+                request,
+                "domain_dns_record_form_response.html",
+                {"dns_record": None, "domain": self.object, "form": self.get_form()},
+                headers={"HX-TRIGGER": "messagesRefresh"},
+            )
 
         finally:
             self.client.close()
 
-        filled_form = DomainDNSRecordForm(initial=self.dns_record)
+        filled_form = DomainDNSRecordForm(initial=self.record_dict_for_initial_data(self.dns_record))
         # Grabbed result data to pass into the form response
-        self.dns_record["form"] = filled_form
+        self.dns_record.form = filled_form
         hx_trigger_events = json.dumps({"messagesRefresh": "", "recordSubmitSuccess": ""})
         row_index = len(self.get_context_data()["dns_records"])
         new_form = DomainDNSRecordForm()


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4752 

## Changes
<!-- What was added, updated, or removed in this PR. -->

_**Also added comments to the files**_

1. Changed ttl field from ChoiceField to TypedChoiceField(coerce=int) so the cleaned value is an integer, preventing a TypeError when the model's clean() method compares self.ttl < 60.
2.  Made create_dns_record and update_dns_record consistent with all other service methods: re-raise HTTPStatusError directly instead of wrapping it in APIError. Error conversion is now handled at the DnsHostService layer.
3. updated create_and_save_record and update_and_save_record to catch both APIError and HTTPStatusError from the vendor service and re-raise as APIError, keeping the view's error handling unchanged.
4. create_db_record returns the DnsRecord model instance, it returned None. The view needed the real model instance to attach a form and render the edit row, a plain dict can't reliably attribute assignment/ template attribute resolution. This gives the view a picklable DnsRecord object to work with, rather than a raw vendor dict.
5. In DomainDNSRecordsView.post, changed the fallback when no DnsRecord DB instance is returned from self.dns_record = record_response["result"] (raw dict) to self.dns_record = None. Passing a plain dict caused domain_dns_record_edit_form.html to crash when {% input_with_errors dns_record.form.name %} resolved dns_record.form to an empty string.
6. Updated test_post_valid_forms_create_records_success to create a real DnsRecord in the test zone and include it in the mock's return value, matching what the real service returns and allowing _attach_form to run so the template renders correctly. 
7. Fixed test_updates_domains_to_delete to guarantee oder. Without ordering, the queryset was returning test2.gov before test.gov (for example) so the ProtectedError was hitting test2.gov (the one that should succeed) and leaving test.gov (which should fail) as the only successful deletion, the opposite of what the test expects. [This was in this other PR](https://github.com/cisagov/manage.get.gov/pull/4792/changes/5da8b77e27f42078ad4a67dace541ce145b50e04)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Code Review Verification Steps

Locally you can run:

```
docker compose up
docker compose exec app ./manage.py test --parallel=1 2>&1 | tee out.log
```

And then also the CI run on this PR should pass.

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
