### PR TITLE
#4852 - Send expiration emails for domains in UNKNOWN state

### DIFF
--- a/ops/scripts/rotate_login_certs.sh
+++ b/ops/scripts/rotate_login_certs.sh
@@ -31,9 +31,15 @@ fi
 echo "Targeting space"
 cf target -o cisa-dotgov -s $1
 
+# EMAIL="nicolle.leclair@ecstech.com" #--Hardcoded email for batch jobs
+read -p "Enter email: " $EMAIL
+
 echo "Creating new login.gov credentials for $1..."
 django_key=$(python3 -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
-openssl req -noenc -x509 -days 365 -newkey rsa:2048 -keyout private-$1.pem -out public-$1.crt
+openssl req -noenc -x509 -days 365 -newkey rsa:2048 \
+  -keyout private-$1.pem \
+  -out public-$1.crt \
+  -subj "/C=US/ST=DC/L=DC/O=DHS/OU=CISA/CN=$1/emailAddress=$EMAIL"
 login_key=$(base64 -i private-$1.pem)
 
 echo "Creating the final json"

--- a/ops/scripts/rotate_login_certs.sh
+++ b/ops/scripts/rotate_login_certs.sh
@@ -31,15 +31,9 @@ fi
 echo "Targeting space"
 cf target -o cisa-dotgov -s $1
 
-# EMAIL="nicolle.leclair@ecstech.com" #--Hardcoded email for batch jobs
-read -p "Enter email: " $EMAIL
-
 echo "Creating new login.gov credentials for $1..."
 django_key=$(python3 -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
-openssl req -noenc -x509 -days 365 -newkey rsa:2048 \
-  -keyout private-$1.pem \
-  -out public-$1.crt \
-  -subj "/C=US/ST=DC/L=DC/O=DHS/OU=CISA/CN=$1/emailAddress=$EMAIL"
+openssl req -noenc -x509 -days 365 -newkey rsa:2048 -keyout private-$1.pem -out public-$1.crt
 login_key=$(base64 -i private-$1.pem)
 
 echo "Creating the final json"

--- a/src/registrar/management/commands/delete_expired_domains_not_setup.py
+++ b/src/registrar/management/commands/delete_expired_domains_not_setup.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             if domain.expiration_date is None:
                 logger.warning(
                     "Domain %s (id: %s) has a null expiration date in state %s. "
-                    "Using creation date + 30 days as default expiration instead.",
+                    "Using creation date + 1 yr as default expiration instead.",
                     domain.name,
                     domain.id,
                     domain.state,

--- a/src/registrar/management/commands/delete_expired_domains_not_setup.py
+++ b/src/registrar/management/commands/delete_expired_domains_not_setup.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
     def get_domains(self):
         """Get domains with DNS status DNS needed or Unknown
         whose expiration date is equal to the current date.
-        If the domain has a null expiration date, creation date + 30 days is used
+        If the domain has a null expiration date, creation date + 1yr is used
         as a default expiration date instead.
         We check for null expiration dates because expiration is not currently
         applied to domains in UNKNOWN state. We do not expect it to be null
@@ -67,7 +67,7 @@ class Command(BaseCommand):
                     domain.id,
                     domain.state,
                 )
-                default_expiration = domain.creation_date + timedelta(days=30)
+                default_expiration = domain.creation_date + timedelta(days=365)
                 if default_expiration != today_date:
                     domains_in_expired_state = domains_in_expired_state.exclude(id=domain.id)
 

--- a/src/registrar/management/commands/delete_expired_domains_not_setup.py
+++ b/src/registrar/management/commands/delete_expired_domains_not_setup.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from django.core.management import BaseCommand
 from registrar.models import Domain, UserDomainRole
 import logging
@@ -25,7 +26,7 @@ class Command(BaseCommand):
     def logging_message(self, dry_run, domains):
         count = len(domains)
         if dry_run:
-            logger.info(f"DRY RUN MODE - No changes will be made\n {count} domains will be deleted")
+            logger.info(f"DRY RUN MODE - No changes will be made\n {count} domains will be deleted if not in dry run mode: {domains}")
         else:
             if count > 1:
                 logger.info(f"{count} domains have been deleted: {domains}")
@@ -42,12 +43,33 @@ class Command(BaseCommand):
         return super().add_arguments(parser)
 
     def get_domains(self):
-        """Get domains with DNS status DNS needed or Unknown"""
-        domain_state = [Domain.State.DNS_NEEDED, Domain.State.UNKNOWN]
-        time_to_compare = timezone.now().date()
+        """Get domains with DNS status DNS needed or Unknown
+        whose expiration date is equal to the current date.
+        If the domain has a null expiration date, creation date + 30 days is used
+        as a default expiration date instead.
+        We check for null expiration dates because expiration is not currently
+        applied to domains in UNKNOWN state. We do not expect it to be null
+        for any other domain state."""
+        today_date = timezone.now().date()
+
         domains_in_expired_state = Domain.objects.filter(
-            state__in=(domain_state), expiration_date=time_to_compare
+            state__in=[Domain.State.DNS_NEEDED, Domain.State.UNKNOWN],
+        ).filter(
+            Q(expiration_date=today_date) | Q(expiration_date__isnull=True)
         ).order_by("id")
+
+        for domain in domains_in_expired_state:
+            if domain.expiration_date is None:
+                logger.warning(
+                    "Domain %s (id: %s) has a null expiration date in state %s. "
+                    "Using creation date + 30 days as default expiration instead.",
+                    domain.name,
+                    domain.id,
+                    domain.state,
+                )
+                default_expiration = domain.creation_date + timedelta(days=30)
+                if default_expiration != today_date:
+                    domains_in_expired_state = domains_in_expired_state.exclude(id=domain.id)
 
         return domains_in_expired_state
 

--- a/src/registrar/management/commands/delete_expired_domains_not_setup.py
+++ b/src/registrar/management/commands/delete_expired_domains_not_setup.py
@@ -27,7 +27,10 @@ class Command(BaseCommand):
     def logging_message(self, dry_run, domains):
         count = len(domains)
         if dry_run:
-            logger.info(f"DRY RUN MODE - No changes will be made\n {count} domains will be deleted if not in dry run mode: {domains}")
+            logger.info(
+                f"DRY RUN MODE - No changes will be made\n {count}"
+                f"domains will be deleted if not in dry run mode:{[d.name for d in domains]}"
+            )
         else:
             if count > 1:
                 logger.info(f"{count} domains have been deleted: {domains}")
@@ -53,11 +56,13 @@ class Command(BaseCommand):
         for any other domain state."""
         today_date = timezone.now().date()
 
-        domains_in_expired_state = Domain.objects.filter(
-            state__in=[Domain.State.DNS_NEEDED, Domain.State.UNKNOWN],
-        ).filter(
-            Q(expiration_date=today_date) | Q(expiration_date__isnull=True)
-        ).order_by("id")
+        domains_in_expired_state = (
+            Domain.objects.filter(
+                state__in=[Domain.State.DNS_NEEDED, Domain.State.UNKNOWN],
+            )
+            .filter(Q(expiration_date=today_date) | Q(expiration_date__isnull=True))
+            .order_by("id")
+        )
 
         for domain in domains_in_expired_state:
             if domain.expiration_date is None:
@@ -68,7 +73,7 @@ class Command(BaseCommand):
                     domain.id,
                     domain.state,
                 )
-                default_expiration = domain.creation_date + timedelta(days=365)
+                default_expiration = domain.created_at + timedelta(days=365)
                 if default_expiration != today_date:
                     domains_in_expired_state = domains_in_expired_state.exclude(id=domain.id)
 

--- a/src/registrar/management/commands/delete_expired_domains_not_setup.py
+++ b/src/registrar/management/commands/delete_expired_domains_not_setup.py
@@ -5,6 +5,7 @@ import logging
 import argparse
 from django.utils import timezone
 from registrar.utility.email import EmailSendingError, send_templated_email
+from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -6,6 +6,7 @@ from django.core.management import BaseCommand
 
 from django.utils import timezone
 
+from registrar.management.commands.utility.terminal_helper import TerminalColors, TerminalHelper
 from registrar.models import Domain, UserDomainRole, UserPortfolioPermission
 from registrar.models.user import UserPortfolioRoleChoices
 from registrar.utility.email import send_templated_email, EmailSendingError
@@ -28,7 +29,7 @@ class Command(BaseCommand):
             help="Print emails that would be sent without actually sending them",
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: C901
         """
         How to run it in dry run mode:
         ./manage.py send_expiring_soon_domains_notification --dry-run
@@ -39,14 +40,15 @@ class Command(BaseCommand):
         today = timezone.now().date()
 
         days_to_check = [30, 7, 1]
-        
+
         # Check for expiring domains that have an expiration date in the next 30, 7, or 1 days,
         # as well as UNKNOWN domains with null expiration date
         # NOTE: We want to re-examine setting an expiration date for UNKNOWN state domains,
-        # which would allow us to remove the check for null expiration dates here and in delete_expired_domains_not_setup.py
+        # which would allow us to remove the check for null expiration dates here and in
+        # delete_expired_domains_not_setup.py
         expiring_domains = Domain.objects.filter(
-            Q(expiration_date__in=[today + timedelta(days=d) for d in days_to_check]) |
-            Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN])
+            Q(expiration_date__in=[today + timedelta(days=d) for d in days_to_check])
+            | Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN])
         )
         logger.info(f"Found {expiring_domains.count()} domains expiring in 30, 7, or 1 days")
 
@@ -57,24 +59,31 @@ class Command(BaseCommand):
 
             forecast_expiration_date = today + timedelta(days=days_remaining)
             domains = Domain.objects.filter(
-                Q(expiration_date=forecast_expiration_date) |
-                Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN],
-                  creation_date=forecast_expiration_date - timedelta(days=365))
+                Q(expiration_date=forecast_expiration_date)
+                | Q(
+                    expiration_date__isnull=True,
+                    state__in=[Domain.State.UNKNOWN],
+                    created_at=forecast_expiration_date - timedelta(days=365),
+                )
             )
-
             logger.info(f"Found {domains.count()} domains expiring in {days_remaining} days")
 
             for domain in domains:
                 effective_expiration = domain.expiration_date
+
+                logger.info(
+                    f"{TerminalColors.MAGENTA}Domain {domain.name} (id: {domain.id})"
+                    f"has status {domain.state}, expiration date {domain.expiration_date},"
+                    f"and creation date {domain.created_at}{TerminalColors.ENDC}"
+                )
                 if domain.expiration_date is None:
+                    effective_expiration = (domain.created_at + timedelta(days=365)).date()
                     logger.warning(
-                        "Domain %s (id: %s) has a null expiration date in state %s. "
-                        "Using creation date +  1yr as default expiration instead.",
-                        domain.name,
-                        domain.id,
-                        domain.state,
+                        f"{TerminalColors.YELLOW}Domain {domain.name} (id: {domain.id}) has a"
+                        f"null expiration date in state {domain.state}. "
+                        f"Using creation date +  1yr instead for an effective expiration of"
+                        f"{effective_expiration}.{TerminalColors.ENDC}"
                     )
-                    effective_expiration = domain.creation_date + timedelta(days=365)
 
                 if domain.state == Domain.State.READY:
                     template = "emails/ready_and_expiring_soon.txt"
@@ -128,7 +137,10 @@ class Command(BaseCommand):
                             cc_addresses=portfolio_admin_emails,
                             context=context,
                         )
-                        logger.info(f"Sent email for domain {domain.name} to managers and CC’d org admins")
+                        logger.info(
+                            f"{TerminalColors.OKGREEN}Sent email {template} with context {context}"
+                            f"for domain {domain.name} to managers and CC’d org admins{TerminalColors.ENDC}"
+                        )
                 except EmailSendingError as err:
                     if not dryrun:
                         logger.error(

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -38,17 +38,44 @@ class Command(BaseCommand):
         today = timezone.now().date()
 
         days_to_check = [30, 7, 1]
-        expiring_domains = Domain.objects.filter(expiration_date__in=[today + timedelta(days=d) for d in days_to_check])
+        
+        # Check for expiring domains that have an expiration date in the next 30, 7, or 1 days,
+        # as well as domains with null expiration date in UNKNOWN state
+        # (since those are currently the only domains that can be expiring soon without an expiration date)
+        # NOTE: We want to re-examine setting an expiration date for UNKNOWN state domains,
+        # which would allow us to remove the check for null expiration dates here and in delete_expired_domains_not_setup.py
+        expiring_domains = Domain.objects.filter(
+            Q(expiration_date__in=[today + timedelta(days=d) for d in days_to_check]) |
+            Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN])
+        )
         logger.info(f"Found {expiring_domains.count()} domains expiring in 30, 7, or 1 days")
 
+        # For each domain that is expiring soon, send an email to the domain managers and CC organization admins.
+        # Check each day threshold separately so that the email content can be customized based on
+        # how many days until expiration
         for days_remaining in days_to_check:
 
-            expiration_day = today + timedelta(days=days_remaining)
-            domains = Domain.objects.filter(expiration_date=expiration_day)
+            forecast_expiration_date = today + timedelta(days=days_remaining)
+            domains = Domain.objects.filter(
+                Q(expiration_date=forecast_expiration_date) |
+                Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN],
+                  creation_date=forecast_expiration_date - timedelta(days=30))
+            )
 
             logger.info(f"Found {domains.count()} domains expiring in {days_remaining} days")
 
             for domain in domains:
+                effective_expiration = domain.expiration_date
+                if domain.expiration_date is None:
+                    logger.warning(
+                        "Domain %s (id: %s) has a null expiration date in state %s. "
+                        "Using creation date + 30 days as default expiration instead.",
+                        domain.name,
+                        domain.id,
+                        domain.state,
+                    )
+                    effective_expiration = domain.creation_date + timedelta(days=30)
+
                 if domain.state == Domain.State.READY:
                     template = "emails/ready_and_expiring_soon.txt"
                     subject_template = "emails/ready_and_expiring_soon_subject.txt"
@@ -61,7 +88,7 @@ class Command(BaseCommand):
                 context = {
                     "domain": domain,
                     "days_remaining": days_remaining,
-                    "expiration_date": domain.expiration_date,
+                    "expiration_date": effective_expiration,
                 }
 
                 # -- GRAB DOMAIN MANAGER EMAILS --

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -10,6 +10,7 @@ from registrar.models import Domain, UserDomainRole, UserPortfolioPermission
 from registrar.models.user import UserPortfolioRoleChoices
 from registrar.utility.email import send_templated_email, EmailSendingError
 from django.template.loader import render_to_string
+from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -48,7 +48,9 @@ class Command(BaseCommand):
         # delete_expired_domains_not_setup.py
         expiring_domains = Domain.objects.filter(
             Q(expiration_date__in=[today + timedelta(days=d) for d in days_to_check])
-            | Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN])
+            | Q(expiration_date__isnull=True,
+                state__in=[Domain.State.UNKNOWN],
+                created_at__in=[today + timedelta(days=d) - timedelta(days=365) for d in days_to_check],)
         )
         logger.info(f"Found {expiring_domains.count()} domains expiring in 30, 7, or 1 days")
 

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -48,9 +48,11 @@ class Command(BaseCommand):
         # delete_expired_domains_not_setup.py
         expiring_domains = Domain.objects.filter(
             Q(expiration_date__in=[today + timedelta(days=d) for d in days_to_check])
-            | Q(expiration_date__isnull=True,
+            | Q(
+                expiration_date__isnull=True,
                 state__in=[Domain.State.UNKNOWN],
-                created_at__in=[today + timedelta(days=d) - timedelta(days=365) for d in days_to_check],)
+                created_at__in=[today + timedelta(days=d) - timedelta(days=365) for d in days_to_check],
+            )
         )
         logger.info(f"Found {expiring_domains.count()} domains expiring in 30, 7, or 1 days")
 

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
                 if domain.expiration_date is None:
                     logger.warning(
                         "Domain %s (id: %s) has a null expiration date in state %s. "
-                        "Using creation date + 30 days as default expiration instead.",
+                        "Using creation date +  1yr as default expiration instead.",
                         domain.name,
                         domain.id,
                         domain.state,

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -40,8 +40,7 @@ class Command(BaseCommand):
         days_to_check = [30, 7, 1]
         
         # Check for expiring domains that have an expiration date in the next 30, 7, or 1 days,
-        # as well as domains with null expiration date in UNKNOWN state
-        # (since those are currently the only domains that can be expiring soon without an expiration date)
+        # as well as UNKNOWN domains with null expiration date
         # NOTE: We want to re-examine setting an expiration date for UNKNOWN state domains,
         # which would allow us to remove the check for null expiration dates here and in delete_expired_domains_not_setup.py
         expiring_domains = Domain.objects.filter(
@@ -59,7 +58,7 @@ class Command(BaseCommand):
             domains = Domain.objects.filter(
                 Q(expiration_date=forecast_expiration_date) |
                 Q(expiration_date__isnull=True, state__in=[Domain.State.UNKNOWN],
-                  creation_date=forecast_expiration_date - timedelta(days=30))
+                  creation_date=forecast_expiration_date - timedelta(days=365))
             )
 
             logger.info(f"Found {domains.count()} domains expiring in {days_remaining} days")
@@ -74,7 +73,7 @@ class Command(BaseCommand):
                         domain.id,
                         domain.state,
                     )
-                    effective_expiration = domain.creation_date + timedelta(days=30)
+                    effective_expiration = domain.creation_date + timedelta(days=365)
 
                 if domain.state == Domain.State.READY:
                     template = "emails/ready_and_expiring_soon.txt"

--- a/src/registrar/management/commands/send_expiring_soon_domains_notification.py
+++ b/src/registrar/management/commands/send_expiring_soon_domains_notification.py
@@ -6,7 +6,7 @@ from django.core.management import BaseCommand
 
 from django.utils import timezone
 
-from registrar.management.commands.utility.terminal_helper import TerminalColors, TerminalHelper
+from registrar.management.commands.utility.terminal_helper import TerminalColors
 from registrar.models import Domain, UserDomainRole, UserPortfolioPermission
 from registrar.models.user import UserPortfolioRoleChoices
 from registrar.utility.email import send_templated_email, EmailSendingError

--- a/src/registrar/tests/test_emails.py
+++ b/src/registrar/tests/test_emails.py
@@ -578,7 +578,7 @@ class SendExpirationEmailsTests(TestCase):
     @patch("django.utils.timezone.now")
     def test_emails_sent_for_unknown_domain_expiring_soon(self, mock_now, mock_send_email):
         """
-        1. Email should send if domain is expiring soon in UNKNOWN state
+        1. Email should send if domain is expiring soon in UNKNOWN state (WITH expiration date set)
         2. Getting the right template
         3. Sending the correct context to the right people (domain manager, org admin)
         """
@@ -699,6 +699,69 @@ class SendExpirationEmailsTests(TestCase):
         call_command("send_expiring_soon_domains_notification")
 
         mock_send_email.assert_not_called()
+
+    @patch("registrar.management.commands.send_expiring_soon_domains_notification.send_templated_email")
+    @patch("django.utils.timezone.now")
+    def test_emails_sent_for_unknown_domain_null_expiration(self, mock_now, mock_send_email):
+        """
+        If a domain in UNKNOWN state has a null expiration date, e-mails default to using
+        creation date + 1 year as the default expiration date. This tests that:
+
+        1. Email sends if domain in UNKNOWN state and has NULL expiration date
+        but is *effectively* expiring soon (using creation date + 1 year as default)
+        2. Getting the right template
+        3. Sending the correct context to the right people (domain manager, org admin)
+        4. Logging a warning that the domain has a null expiration date and that we're defaulting to using creation date + 1 year
+        """
+        mock_now.return_value = timezone.make_aware(datetime.combine(self.fixed_today, datetime.min.time()))
+
+        # Set EFFECTIVE expiration to be 30 days out from today (to trigger 30 day e-mail)
+        # Do this by setting creation date to be 1 year ago + 30 days,
+        # since default expiration is creation + 1 year for null expiration date fields
+        one_year_timedelta = timedelta(days=365)
+        creation_date = self.fixed_today - one_year_timedelta + timedelta(days=30)
+
+        domain_unknown = Domain.objects.create(
+            name="unknown_null_exp.gov",
+            state=Domain.State.UNKNOWN,
+            expiration_date=None,
+            creation_date=creation_date,
+        )
+        portfolio = Portfolio.objects.create(requester=self.admin, organization_name="Null Expirations Portfolio")
+        DomainInformation.objects.create(domain=domain_unknown, portfolio=portfolio, requester=self.manager)
+
+        UserDomainRole.objects.create(user=self.manager, domain=domain_unknown, role="manager")
+
+        UserPortfolioPermission.objects.create(
+            user=self.manager,
+            portfolio=portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+        )
+        UserPortfolioPermission.objects.create(
+            user=self.admin,
+            portfolio=portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+        )
+
+        with self.assertLogs("registrar.management.commands.send_expiring_soon_domains_notification", level="WARNING") as log:
+            call_command("send_expiring_soon_domains_notification")
+
+        # Confirm warning was raised about null expiration
+        self.assertTrue(any("null expiration" in msg.lower() for msg in log.output))
+
+        expected_context = {
+            "domain": domain_unknown,
+            "days_remaining": 30,
+            "expiration_date": creation_date + one_year_timedelta,
+        }
+
+        mock_send_email.assert_any_call(
+            "emails/dns_needed_or_unknown_expiring_soon.txt",
+            "emails/dns_needed_or_unknown_expiring_soon_subject.txt",
+            to_addresses=["manager@example.com"],
+            cc_addresses=["admin@example.com"],
+            context=expected_context,
+        )
 
 
 class SendDomainSetupReminderTests(TestCase):

--- a/src/registrar/tests/test_emails.py
+++ b/src/registrar/tests/test_emails.py
@@ -623,6 +623,66 @@ class SendExpirationEmailsTests(TestCase):
 
     @patch("registrar.management.commands.send_expiring_soon_domains_notification.send_templated_email")
     @patch("django.utils.timezone.now")
+    def test_emails_sent_for_unknown_domain_null_expiration(self, mock_now, mock_send_email):
+        """
+        If a domain in UNKNOWN state has a null expiration date, e-mails default to using
+        creation date + 1 year as the default expiration date. This tests that:
+
+        1. Email sends if domain in UNKNOWN state and has NULL expiration date
+        but is *effectively* expiring soon (using creation date + 1 year as default)
+        2. Getting the right template
+        3. Sending the correct context to the right people (domain manager, org admin)
+        """
+        mock_now.return_value = timezone.make_aware(datetime.combine(self.fixed_today, datetime.min.time()))
+
+        # Set EFFECTIVE expiration to be 30 days out from today (to trigger 30 day e-mail)
+        # Do this by setting creation date to be 1 year ago + 30 days,
+        # since default expiration is creation + 1 year for null expiration date fields
+
+        domain_unknown = Domain.objects.create(
+            name="unknown_null_expiration.gov",
+            state=Domain.State.UNKNOWN,
+            expiration_date=None,
+        )
+        # Override the auto-set creation date
+        creation_date = self.fixed_today - timedelta(days=365 - 30)
+        domain_unknown.created_at = creation_date
+        domain_unknown.save(update_fields=["created_at"])
+
+        portfolio = Portfolio.objects.create(requester=self.admin, organization_name="Null Expirations Portfolio")
+        DomainInformation.objects.create(domain=domain_unknown, portfolio=portfolio, requester=self.manager)
+
+        UserDomainRole.objects.create(user=self.manager, domain=domain_unknown, role="manager")
+
+        UserPortfolioPermission.objects.create(
+            user=self.manager,
+            portfolio=portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+        )
+        UserPortfolioPermission.objects.create(
+            user=self.admin,
+            portfolio=portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+        )
+
+        call_command("send_expiring_soon_domains_notification")
+
+        expected_context = {
+            "domain": domain_unknown,
+            "days_remaining": 30,
+            "expiration_date": creation_date + timedelta(days=365),
+        }
+
+        mock_send_email.assert_any_call(
+            "emails/dns_needed_or_unknown_expiring_soon.txt",
+            "emails/dns_needed_or_unknown_expiring_soon_subject.txt",
+            to_addresses=["manager@example.com"],
+            cc_addresses=["admin@example.com"],
+            context=expected_context,
+        )
+
+    @patch("registrar.management.commands.send_expiring_soon_domains_notification.send_templated_email")
+    @patch("django.utils.timezone.now")
     def test_no_emails_for_unrelated_domain_states(self, mock_now, mock_send_email):
         """
         1. Email should NOT send if it is expiring soon
@@ -699,69 +759,6 @@ class SendExpirationEmailsTests(TestCase):
         call_command("send_expiring_soon_domains_notification")
 
         mock_send_email.assert_not_called()
-
-    @patch("registrar.management.commands.send_expiring_soon_domains_notification.send_templated_email")
-    @patch("django.utils.timezone.now")
-    def test_emails_sent_for_unknown_domain_null_expiration(self, mock_now, mock_send_email):
-        """
-        If a domain in UNKNOWN state has a null expiration date, e-mails default to using
-        creation date + 1 year as the default expiration date. This tests that:
-
-        1. Email sends if domain in UNKNOWN state and has NULL expiration date
-        but is *effectively* expiring soon (using creation date + 1 year as default)
-        2. Getting the right template
-        3. Sending the correct context to the right people (domain manager, org admin)
-        4. Logging a warning that the domain has a null expiration date and that we're defaulting to using creation date + 1 year
-        """
-        mock_now.return_value = timezone.make_aware(datetime.combine(self.fixed_today, datetime.min.time()))
-
-        # Set EFFECTIVE expiration to be 30 days out from today (to trigger 30 day e-mail)
-        # Do this by setting creation date to be 1 year ago + 30 days,
-        # since default expiration is creation + 1 year for null expiration date fields
-        one_year_timedelta = timedelta(days=365)
-        creation_date = self.fixed_today - one_year_timedelta + timedelta(days=30)
-
-        domain_unknown = Domain.objects.create(
-            name="unknown_null_exp.gov",
-            state=Domain.State.UNKNOWN,
-            expiration_date=None,
-            creation_date=creation_date,
-        )
-        portfolio = Portfolio.objects.create(requester=self.admin, organization_name="Null Expirations Portfolio")
-        DomainInformation.objects.create(domain=domain_unknown, portfolio=portfolio, requester=self.manager)
-
-        UserDomainRole.objects.create(user=self.manager, domain=domain_unknown, role="manager")
-
-        UserPortfolioPermission.objects.create(
-            user=self.manager,
-            portfolio=portfolio,
-            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
-        )
-        UserPortfolioPermission.objects.create(
-            user=self.admin,
-            portfolio=portfolio,
-            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
-        )
-
-        with self.assertLogs("registrar.management.commands.send_expiring_soon_domains_notification", level="WARNING") as log:
-            call_command("send_expiring_soon_domains_notification")
-
-        # Confirm warning was raised about null expiration
-        self.assertTrue(any("null expiration" in msg.lower() for msg in log.output))
-
-        expected_context = {
-            "domain": domain_unknown,
-            "days_remaining": 30,
-            "expiration_date": creation_date + one_year_timedelta,
-        }
-
-        mock_send_email.assert_any_call(
-            "emails/dns_needed_or_unknown_expiring_soon.txt",
-            "emails/dns_needed_or_unknown_expiring_soon_subject.txt",
-            to_addresses=["manager@example.com"],
-            cc_addresses=["admin@example.com"],
-            context=expected_context,
-        )
 
 
 class SendDomainSetupReminderTests(TestCase):


### PR DESCRIPTION
## Ticket 4852

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4852 

## Changes

<!-- What was added, updated, or removed in this PR. -->
Currently, UNKNOWN domains do not have expiration_date set (they are `null`).  We want to expire them 1 year after the creation date and send the relevant expiring soon e-mails.  To do this, the following scripts responsible for e-mail sending and deletion of expired domains were updated as follows;

- Updated `send_expiring_soon_domains_notification.py` so that it checks for `null` expiration dates in UNKNOWN domains and defaults to creation date + 1 year as the _effective_ expiration date for e-mail sending
- Updated `delete_expired_domains_not_setup.py` so that we actually follow-through and delete domains in the UNKNOWN state (using creation date + 30 days as the default expiration if the expiration date is null)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

This is an **interim workaround** for the presence of null expiration dates.  We will be re-examining expirations for domains in the UNKNOWN state in the future.  For now, we need to be able to effectively expire UNKNOWN domains, send the appropriate emails, and then tombstone (soft delete) them when their time is up.

## Setup


## Code Review Verification Steps

1. In your database, locate one or more domains in the UNKNOWN state and confirm they have a null expiration_date.

2. Note the creation_date of those domains. The effective expiration used by both scripts will be creation_date + 30 days.

3. Run the expiring-soon notification script in dry run mode:
   ./manage.py send_expiring_soon_domains_notification --dry-run

   Verify that:
   - [ ] The script creates a warning log for each UNKNOWN domain with a null expiration_date,
     including the domain name, id, state, and note about using creation + 30 days.
   - [ ] An email is set to be sent for these UNKNOWN domains
   - [ ] The correct effective expiration date is reflected in email output.

4. Run the deletion script in dry run mode:
   ./manage.py delete_expired_domains_not_setup --dry-run

   Verify that:
   - [ ] The script creates a warning log for each UNKNOWN domain with a null expiration_date,
     including the domain name, id, state, and note about using creation + 30 days.
   - [ ] UNKNOWN domains with null expiration dates and whose creation_date + 30 days matches today are included
     in the deletion candidate list.

5. Run the above scripts without dry run and verify that:
  - [ ] The correct e-mails send for UNKNOWN domains
  - [ ] UNKNOWN domains that have expired (creation_date + 30 days matches today) are deleted

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
