### PR TITLE
#4777:Form Comment Character Remains After Cancel Bug

### DIFF
--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -164,9 +164,6 @@ export function initDynamicDNSRecordFormFields() {
     })
 
     typeField.addEventListener('change', function (e){
-        if(e.isTrusted){
-            clearRecordForm()
-        }
 
         const selectedType = this.value;
         const info = config[selectedType];
@@ -202,4 +199,8 @@ export function initDynamicDNSRecordFormFields() {
         typeField.dispatchEvent(new Event('change'));
     }
 
+    // clearForm on cancel
+    document.getElementById("dnsrecords-cancel-button").addEventListener('click', function(e){
+        clearRecordForm()
+    })
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -79,11 +79,13 @@ function clearRecordForm(){
     const alertMessagesContainer = document.getElementById('messages-container')
     
     alertMessagesContainer.querySelectorAll('.usa-alert').forEach(el => el.remove())
-
-    // reset count for comment field
+    
     // clear comment field
-    // comment character count is hardcoded due to the model having different max length limits. Should be updated if/when max length is updated on the model
     document.getElementById('id_comment').value = ''
+    const commentStatus =  document.getElementById('dnsrecords-form-container-comment--status')
+    // remove error styling on count text
+    commentStatus.classList.remove("usa-character-count__status--invalid")
+     // reset count for comment field, character count is hardcoded for now if/when the model is updated with the current maxlength
     document.getElementById('dnsrecords-form-container-comment--status').textContent = getCharCountText(100, 0)
     
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -64,8 +64,8 @@ function clearRecordForm(){
 
     inputs.forEach(input =>{ 
         input.classList.remove("usa-input--error")
-        input.value = ""
     })
+
 
     // remove label styling
     const labels = form.querySelectorAll('label')
@@ -79,7 +79,9 @@ function clearRecordForm(){
     document.querySelectorAll('.usa-alert--error').forEach(el => el.remove())
 
     // reset count for comment field
+    // clear comment field
     // comment character count is hardcoded due to the model having different max length limits. Should be updated if/when max length is updated on the model
+    document.getElementById('id_comment').value = ''
     document.getElementById('dnsrecords-form-container-comment--status').textContent = getCharCountText(100, 0)
     
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -163,10 +163,7 @@ export function initDynamicDNSRecordFormFields() {
     })
 
     typeField.addEventListener('change', function (e){
-        if(e.isTrusted){
-            clearRecordForm()
-        }
-
+        
         const selectedType = this.value;
         const info = config[selectedType];
         const contentLabel = document.querySelector('label[for=id_content]');

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -64,6 +64,7 @@ function clearRecordForm(){
 
     inputs.forEach(input =>{ 
         input.classList.remove("usa-input--error")
+        input.value = ""
     })
 
     // remove label styling

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -75,8 +75,10 @@ function clearRecordForm(){
     // remove error messages that appear on the top of the page
     form.querySelectorAll('.usa-error-message').forEach( el =>{ el.remove()})
 
-    // remove top message errors
-    document.querySelectorAll('.usa-alert--error').forEach(el => el.remove())
+    // remove top message alerts
+    const alertMessagesContainer = document.getElementById('messages-container')
+    
+    alertMessagesContainer.querySelectorAll('.usa-alert').forEach(el => el.remove())
 
     // reset count for comment field
     // clear comment field

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -57,8 +57,9 @@ function switchFromInputToTextArea (element) {
         textArea.insertAdjacentElement('afterend', displayCharCount)
 }
 
-function clearRecordForm(){
-    const form = document.getElementById("dnsrecords-form-container")
+function clearRecordForm(root){
+    const form = root || document.getElementById("dnsrecords-form-container")
+    if(!form) return;
     
     // remove error styling from inputs and labels 
     const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
@@ -203,7 +204,8 @@ export function initDynamicDNSRecordFormFields() {
     
     // clearForm when a user hits the cancel button on the dns record form and table
     document.querySelectorAll(".js-dnsrecord-cancel-button").forEach( button => {
-        button.addEventListener('click',clearRecordForm)
+        const formInRow = button.closest('form')
+        button.addEventListener('click',() => clearRecordForm(formInRow))
         }
     )
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -78,6 +78,7 @@ function clearRecordForm(){
     document.querySelectorAll('.usa-alert--error').forEach(el => el.remove())
 
     // reset count for comment field
+    // comment character count is hardcoded due to the model having different max length limits. Should be updated if/when max length is updated on the model
     document.getElementById('dnsrecords-form-container-comment--status').textContent = getCharCountText(100, 0)
     
 }
@@ -163,6 +164,7 @@ export function initDynamicDNSRecordFormFields() {
     })
 
     typeField.addEventListener('change', function (e){
+        // e.isTrusted ensures that this only fires when a user select a new type.
         if(e.isTrusted){
             clearRecordForm()
         }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -60,13 +60,19 @@ function switchFromInputToTextArea (element) {
 function clearRecordForm(){
     const form = document.getElementById("dnsrecords-form-container")
     
+    // remove error styling and reset values  
     const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
 
     inputs.forEach(input =>{ 
         input.classList.remove("usa-input--error")
         input.value = ""})
 
-    
+    // remove label styling
+    const labels = form.querySelectorAll('label')
+
+    labels.forEach( label => label.classList.remove("usa-label--error"))
+
+    // remove error messages that appear on the top of the page
     form.querySelectorAll('.usa-error-message').forEach( el =>{ el.remove()})
 
     // remove top message errors
@@ -159,7 +165,6 @@ export function initDynamicDNSRecordFormFields() {
 
     typeField.addEventListener('change', function (e){
         if(e.isTrusted){
-            console.log("HELLO")
             clearRecordForm()
         }
 

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -59,8 +59,7 @@ function switchFromInputToTextArea (element) {
 
 function clearRecordForm(){
     const form = document.getElementById("dnsrecords-form-container")
-    
-    // remove error styling and reset values  
+// remove error styling and reset values  
     const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
 
     inputs.forEach(input =>{ 
@@ -164,6 +163,9 @@ export function initDynamicDNSRecordFormFields() {
     })
 
     typeField.addEventListener('change', function (e){
+        if(e.isTrusted){
+            clearRecordForm()
+        }
 
         const selectedType = this.value;
         const info = config[selectedType];
@@ -198,7 +200,7 @@ export function initDynamicDNSRecordFormFields() {
     if (typeField.value) {
         typeField.dispatchEvent(new Event('change'));
     }
-
+    
     // clearForm on cancel
     document.getElementById("dnsrecords-cancel-button").addEventListener('click', function(e){
         clearRecordForm()

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -59,35 +59,26 @@ function switchFromInputToTextArea (element) {
 
 function clearRecordForm(){
     const form = document.getElementById("dnsrecords-form-container")
-    // remove error styling and reset values  
+    
+    // remove error styling from inputs and labels 
     const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
-
     inputs.forEach(input =>{ 
         input.classList.remove("usa-input--error")
     })
-
-
-    // remove label styling
     const labels = form.querySelectorAll('label')
-
     labels.forEach( label => label.classList.remove("usa-label--error"))
 
-    // remove error messages that appear on the top of the page
+    // remove error messages in line and top-level error messages
     form.querySelectorAll('.usa-error-message').forEach( el =>{ el.remove()})
-
-    // remove top message alerts
     const alertMessagesContainer = document.getElementById('messages-container')
-    
     alertMessagesContainer.querySelectorAll('.usa-alert').forEach(el => el.remove())
     
-    // clear comment field
+    // Reset the comment field and its character count
     document.getElementById('id_comment').value = ''
     const commentStatus =  document.getElementById('dnsrecords-form-container-comment--status')
-    // remove error styling on count text
     commentStatus.classList.remove("usa-character-count__status--invalid")
-     // reset count for comment field, character count is hardcoded for now if/when the model is updated with the current maxlength
-    document.getElementById('dnsrecords-form-container-comment--status').textContent = getCharCountText(100, 0)
-    
+     // Character count is hardcoded for now if/when the model is updated with the current maxlength
+    commentStatus.textContent = getCharCountText(100, 0)
 }
 
 export function editAndCommentButtonListener (){
@@ -210,11 +201,9 @@ export function initDynamicDNSRecordFormFields() {
         typeField.dispatchEvent(new Event('change'));
     }
     
-    // clearForm on cancel
+    // clearForm when a user hits the cancel button on the dns record form and table
     document.querySelectorAll(".js-dnsrecord-cancel-button").forEach( button => {
-        button.addEventListener('click',function(e) {
-            clearRecordForm()
-            })
+        button.addEventListener('click',clearRecordForm)
         }
     )
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -59,7 +59,7 @@ function switchFromInputToTextArea (element) {
 
 function clearRecordForm(){
     const form = document.getElementById("dnsrecords-form-container")
-// remove error styling and reset values  
+    // remove error styling and reset values  
     const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
 
     inputs.forEach(input =>{ 
@@ -209,7 +209,10 @@ export function initDynamicDNSRecordFormFields() {
     }
     
     // clearForm on cancel
-    document.getElementById("dnsrecords-cancel-button").addEventListener('click', function(e){
-        clearRecordForm()
-    })
+    document.querySelectorAll(".js-dnsrecord-cancel-button").forEach( button => {
+        button.addEventListener('click',function(e) {
+            clearRecordForm()
+            })
+        }
+    )
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -57,6 +57,13 @@ function switchFromInputToTextArea (element) {
         textArea.insertAdjacentElement('afterend', displayCharCount)
 }
 
+function clearRecordForm(){
+    const form = document.getElementById("dnsrecords-form-container")
+    const inputs = form.querySelectorAll('input:not=([type="hidden"]), textarea')
+
+    inputs.forEach(input => input.value = "")
+
+}
 
 export function editAndCommentButtonListener (){
         const table = document.querySelector("#dnsrecords-table");
@@ -85,6 +92,7 @@ export function editAndCommentButtonListener (){
         
         })
 }
+
 
 export function commentCharacterEventListener(){
 
@@ -137,7 +145,11 @@ export function initDynamicDNSRecordFormFields() {
                 }
     })
 
-    typeField.addEventListener('change', function (){
+    typeField.addEventListener('change', function (e){
+        if(e.isTrusted){
+            clearRecordForm()
+        }
+
         const selectedType = this.value;
         const info = config[selectedType];
         const contentLabel = document.querySelector('label[for=id_content]');

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -59,10 +59,22 @@ function switchFromInputToTextArea (element) {
 
 function clearRecordForm(){
     const form = document.getElementById("dnsrecords-form-container")
-    const inputs = form.querySelectorAll('input:not=([type="hidden"]), textarea')
+    
+    const inputs = form.querySelectorAll('input:not([type="hidden"]), textarea')
 
-    inputs.forEach(input => input.value = "")
+    inputs.forEach(input =>{ 
+        input.classList.remove("usa-input--error")
+        input.value = ""})
 
+    
+    form.querySelectorAll('.usa-error-message').forEach( el =>{ el.remove()})
+
+    // remove top message errors
+    document.querySelectorAll('.usa-alert--error').forEach(el => el.remove())
+
+    // reset count for comment field
+    document.getElementById('dnsrecords-form-container-comment--status').textContent = getCharCountText(100, 0)
+    
 }
 
 export function editAndCommentButtonListener (){
@@ -147,6 +159,7 @@ export function initDynamicDNSRecordFormFields() {
 
     typeField.addEventListener('change', function (e){
         if(e.isTrusted){
+            console.log("HELLO")
             clearRecordForm()
         }
 

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -64,7 +64,7 @@ function clearRecordForm(){
 
     inputs.forEach(input =>{ 
         input.classList.remove("usa-input--error")
-        input.value = ""})
+    })
 
     // remove label styling
     const labels = form.querySelectorAll('label')
@@ -163,7 +163,10 @@ export function initDynamicDNSRecordFormFields() {
     })
 
     typeField.addEventListener('change', function (e){
-        
+        if(e.isTrusted){
+            clearRecordForm()
+        }
+
         const selectedType = this.value;
         const info = config[selectedType];
         const contentLabel = document.querySelector('label[for=id_content]');

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -32,7 +32,7 @@
                 </div>
                 <button
                     type="button"
-                    class="usa-button usa-button--outline"
+                    class="usa-button usa-button--outline js-dnsrecord-cancel-button"
                     hx-get="{% url 'domain-dns-records' domain.pk %}"
                     hx-select="#dnsrecord-edit-form-{{ record_id }}"
                     hx-target="#dnsrecord-edit-form-{{ record_id }}"

--- a/src/registrar/templates/domain_dns_record_form_content.html
+++ b/src/registrar/templates/domain_dns_record_form_content.html
@@ -49,6 +49,7 @@
         type="reset"
         class="usa-button usa-button--outline"
         x-on:click="showFormId = null"
+        id="dnsrecords-cancel-button"
     >
         Cancel
     </button>

--- a/src/registrar/templates/domain_dns_record_form_content.html
+++ b/src/registrar/templates/domain_dns_record_form_content.html
@@ -47,9 +47,8 @@
 
     <button
         type="reset"
-        class="usa-button usa-button--outline"
+        class="usa-button usa-button--outline js-dnsrecord-cancel-button"
         x-on:click="showFormId = null"
-        id="dnsrecords-cancel-button"
     >
         Cancel
     </button>


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4777 and #4885 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Created a new function `clearForm` in our js file that clears the errors upon cancel, type field change, and resets count status text.


<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

- Go to dns record form, select any type after hitting "Add Record".
- Start typing in the comments box, and hit cancel.
- Try to add a record again, the comment status should reset back to "100 characters allowed."

- Go to dns record form, select any after hitting "Add Record."
- Creating an error on the page whether not following the suggested format or leaving the fields empty.
- Submit, you should see errors on the top of the page, and on top of the input values
- Hit Cancel on the form, all of the errors should clear on the top of the page.
- When you open the form again, you should not see the errors within the form.

- Go to dns record form, select any after hitting "Add Record."
- Creating an error on the page by submitting an empty record.
- Select a different type from the drop down.
- Errors should clear.
- 
<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps


### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [x] Checked different states (empty, one, some, error)
- [x] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
