### PR TITLE
#4804: Change tab order for the dns form, plus tests.

### DIFF
--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -110,6 +110,160 @@ export function editAndCommentButtonListener (){
         })
 }
 
+// Tab-order routing for the DNS records table (#4804).
+// When a form is open, route Tab to walk:
+//   Edit → form fields → Delete → kebab → next row's Edit
+// Shift+Tab does the reverse. When closed, native order is fine.
+export function initDNSRecordTabOrder() {
+    const table = document.querySelector("#dnsrecords-table");
+    if (!table) return;
+
+    const getOpenRecordId = () => {
+        try { return Alpine.$data(table)?.showFormId; } catch (e) { return null; }
+    };
+
+    // Resolve the focusable elements that participate in our custom tab order for a record.
+    function getRecordElements(recordId) {
+        if (!recordId) return null;
+        const editBtn = table.querySelector(
+            `button[data-action="edit"][data-record-id="${recordId}"]`
+        );
+        const formRow = document.getElementById(`dnsrecord-edit-row-${recordId}`);
+        const kebab = table.querySelector(
+            `button[aria-controls="more-actions-dnsrecord-${recordId}"]`
+        );
+        if (!editBtn || !formRow) return null;
+        const formFirst = formRow.querySelector(
+            'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled])'
+        );
+        const formDelete = formRow.querySelector('[data-action="form-delete"]');
+        return { editBtn, formRow, kebab, formFirst, formDelete };
+    }
+
+    // Find the next record row's Edit button, skipping edit/comment rows between records.
+    // First focusable on the next record row. The comment toggle button
+    // (only rendered when that record has a comment) sits before the Edit
+    // button in DOM, so prefer it when present so screen-reader / keyboard
+    // users don't skip past the comment indicator.
+    function nextRecordEntryAfter(recordId) {
+        let row = document.getElementById(`dnsrecord-row-${recordId}`);
+        while (row?.nextElementSibling) {
+            row = row.nextElementSibling;
+            if (!row.id?.startsWith('dnsrecord-row-')) continue;
+            return row.querySelector('button[data-action="comment"], button[data-action="edit"]');
+        }
+        return null;
+    }
+
+    function nextFocusableAfterElement(node) {
+        const selector = 'a[href], a[tabindex="0"], button:not([disabled]), '
+            + 'input:not([disabled]):not([type="hidden"]), select:not([disabled]), '
+            + 'textarea:not([disabled]), [tabindex="0"]';
+        const candidates = document.querySelectorAll(selector);
+        let past = false;
+        for (const el of candidates) {
+            if (past && el.offsetParent !== null) return el;
+            if (node === el || node.contains(el)) past = true;
+        }
+        return null;
+    }
+
+    // Defer focus calls until Alpine has flushed x-show — otherwise .focus()
+    // hits a still-hidden element and silently no-ops. Alpine.nextTick
+    // handles that; rAF is a safety net for headless Chromium.
+    function deferFocus(fn) {
+        if (window.Alpine?.nextTick) {
+            window.Alpine.nextTick(() => requestAnimationFrame(fn));
+        } else {
+            requestAnimationFrame(fn);
+        }
+    }
+
+    table.addEventListener('click', (e) => {
+        const trigger = e.target.closest('[data-action="edit"], [data-action="form-cancel"]');
+        if (!trigger) return;
+        const recordId = trigger.dataset.recordId;
+        deferFocus(() => {
+            const elems = getRecordElements(recordId);
+            if (!elems) return;
+            const isOpen = getOpenRecordId() === recordId;
+            (isOpen ? elems.formFirst : elems.editBtn)?.focus();
+        });
+    });
+
+    // Intercept Tab to enforce the desired order. We always reroute Tab from the Edit
+    // button explicitly (rather than relying on natural DOM order) because the row's
+    // mobile-only Delete and the USWDS accordion can intercept Tab in ways that vary
+    // by viewport and post-HTMX state.
+    table.addEventListener('keydown', (e) => {
+        if (e.key !== 'Tab') return;
+
+        const t = e.target;
+
+        // Tab/Shift+Tab from any record's Edit button: route based on that record's
+        // form state, regardless of whether any other form is open.
+        const editBtn = t.closest?.('[data-action="edit"]');
+        if (editBtn === t) {
+            const rid = editBtn.dataset.recordId;
+            const r = getRecordElements(rid);
+            if (!r) return;
+            const isOpen = getOpenRecordId() === rid;
+            if (!e.shiftKey) {
+                // Edit -> first form field (open) | kebab (closed)
+                e.preventDefault();
+                (isOpen ? r.formFirst : r.kebab)?.focus();
+            }
+            // Shift+Tab from Edit: let natural DOM order go to the previous focusable.
+            return;
+        }
+
+        // The remaining rules apply only while a form is open.
+        const recordId = getOpenRecordId();
+        if (!recordId) return;
+        const elems = getRecordElements(recordId);
+        if (!elems) return;
+
+        const kebabMenu = elems.kebab
+            ? document.getElementById(elems.kebab.getAttribute('aria-controls'))
+            : null;
+        const isKebabFocus = elems.kebab && (t === elems.kebab || kebabMenu?.contains(t));
+        const nextRecordEntry = nextRecordEntryAfter(recordId);
+
+        // First form field -> Edit (Shift+Tab backward)
+        if (e.shiftKey && t === elems.formFirst) {
+            e.preventDefault();
+            elems.editBtn.focus();
+            return;
+        }
+        // Form Delete -> kebab "More options" (Tab forward)
+        if (!e.shiftKey && elems.formDelete && t === elems.formDelete) {
+            e.preventDefault();
+            elems.kebab?.focus();
+            return;
+        }
+        // Kebab -> Form Delete (Shift+Tab backward, form open)
+        if (e.shiftKey && isKebabFocus) {
+            e.preventDefault();
+            elems.formDelete?.focus();
+            return;
+        }
+        // Next record's Edit -> kebab (Shift+Tab backward, form open)
+        if (e.shiftKey && elems.kebab && t === nextRecordEntry) {
+            e.preventDefault();
+            elems.kebab.focus();
+            return;
+        }
+        // Kebab -> next record's Edit / out of table (Tab forward, form open — skip the
+        // visible form row that would otherwise be next in DOM order).
+        if (!e.shiftKey && isKebabFocus) {
+            const destination = nextRecordEntry || nextFocusableAfterElement(table);
+            if (!destination) return;
+            e.preventDefault();
+            destination.focus();
+            return;
+        }
+    });
+}
 
 export function commentCharacterEventListener(){
 
@@ -201,7 +355,7 @@ export function initDynamicDNSRecordFormFields() {
     if (typeField.value) {
         typeField.dispatchEvent(new Event('change'));
     }
-    
+
     // clearForm when a user hits the cancel button on the dns record form and table
     document.querySelectorAll(".js-dnsrecord-cancel-button").forEach( button => {
         const formInRow = button.closest('form')

--- a/src/registrar/assets/src/js/getgov/main.js
+++ b/src/registrar/assets/src/js/getgov/main.js
@@ -20,7 +20,7 @@ import { domain_purpose_choice_callbacks } from './domain-purpose-form.js';
 import { initButtonLinks } from '../getgov-admin/button-utils.js';
 import { initOrganizationsNavDropdown } from './organizations-dropdown.js';
 import { domainDeletionEventListener } from './domain-deletion-form.js';
-import { initDynamicDNSRecordFormFields, editAndCommentButtonListener, commentCharacterEventListener } from './domain-dns-record-content.js';
+import { initDynamicDNSRecordFormFields, editAndCommentButtonListener, commentCharacterEventListener, initDNSRecordTabOrder } from './domain-dns-record-content.js';
 
 initDomainValidators();
 
@@ -75,6 +75,7 @@ initOrganizationsNavDropdown();
 initDynamicDNSRecordFormFields();
 commentCharacterEventListener()
 editAndCommentButtonListener()
+initDNSRecordTabOrder()
 
 document.addEventListener('htmx:afterSettle', (evt) => {
     initDynamicDNSRecordFormFields();

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -33,6 +33,8 @@
                 <button
                     type="button"
                     class="usa-button usa-button--outline js-dnsrecord-cancel-button"
+                    data-action="form-cancel"
+                    data-record-id="{{ record_id }}"
                     hx-get="{% url 'domain-dns-records' domain.pk %}"
                     hx-select="#dnsrecord-edit-form-{{ record_id }}"
                     hx-target="#dnsrecord-edit-form-{{ record_id }}"
@@ -48,6 +50,10 @@
 
                 <a
                     class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm"
+                    role="button"
+                    tabindex="0"
+                    data-action="form-delete"
+                    data-record-id="{{ record_id }}"
                     aria-label="Delete DNS record from Cloudflare"
                 >
                     <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -265,6 +265,91 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
         self.assertContains(response, "5 minutes")
         self.assertNotContains(response, ">300<", html=False)
 
+    # --- Tab order accessibility (issue #4804) ---
+    # An open DNS record edit form must support a tab sequence of:
+    #   Edit -> Name -> Content -> TTL -> Comment -> Cancel -> Save -> Delete
+    #   -> More options -> next row's Edit
+    # and the same sequence in reverse with Shift+Tab.
+    # Focus reordering is implemented in JS (initDNSRecordTabOrder); these tests assert the
+    # template-side hooks the JS depends on are present, so future refactors don't silently
+    # break the accessibility contract.
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_row_exposes_edit_button_hooks(self):
+        """The Edit button must carry the data-action and data-record-id hooks the
+        tab-order JS uses to identify the row."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, 'data-action="edit"')
+        self.assertContains(response, f'data-record-id="{record.id}"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_row_exposes_kebab_with_aria_controls(self):
+        """The 'More options' kebab must declare aria-controls so the tab-order JS can
+        locate it per record."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, f'aria-controls="more-actions-dnsrecord-{record.id}"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_edit_form_delete_link_is_focusable(self):
+        """The Delete control in the edit form is the 8th item in the tab sequence and
+        must be reachable via keyboard. role=button + tabindex=0 makes it focusable;
+        data-action='form-delete' lets the tab-order JS detect it as the last form pivot."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+        content = response.content.decode()
+
+        # All three markers must appear together on the form's Delete link.
+        self.assertContains(response, 'aria-label="Delete DNS record from Cloudflare"')
+        self.assertContains(response, 'data-action="form-delete"')
+        self.assertContains(response, f'data-record-id="{record.id}"')
+        self.assertIn('role="button"', content)
+        self.assertIn('tabindex="0"', content)
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_edit_form_cancel_button_has_focus_routing_hooks(self):
+        """The Cancel button must carry data-action='form-cancel' so the tab-order JS can
+        return focus to the Edit button when the form closes — otherwise focus is stranded
+        inside the hidden form row and Tab walks past the kebab to the next record."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, 'data-action="form-cancel"')
+        self.assertContains(response, f'data-record-id="{record.id}"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_edit_row_has_stable_id_for_focus_routing(self):
+        """The edit form row id (dnsrecord-edit-row-<id>) is what the tab-order JS uses
+        to find the open form's focusable controls."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, f'id="dnsrecord-edit-row-{record.id}"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_dns_record_readonly_row_has_stable_id_for_focus_routing(self):
+        """The readonly row id (dnsrecord-row-<id>) is what the tab-order JS uses
+        to find the next record's Edit button when routing focus from the kebab."""
+        record = create_dns_record(self.dns_zone)
+
+        response = self.client.get(self._url())
+
+        self.assertContains(response, f'id="dnsrecord-row-{record.id}"')
+
     @override_flag("dns_hosting", active=True)
     @less_console_noise_decorator
     def test_post_edit_unchanged_data_is_not_flagged_as_duplicate(self):


### PR DESCRIPTION
## Ticket

Resolves #4804

## Changes

- Reordered tab focus in DNS record edit forms so Tab from Edit walks through the form fields (Name → Content → TTL → Comment → Cancel → Save → Delete) before landing on the "More options" kebab. When the form is closed, Edit → More options still works as before.
- Made the form's Delete link keyboard-focusable (`role="button"`, `tabindex="0"`) — it wasn't reachable via Tab previously.
- Added template tests covering the focus hooks (`data-action`, `aria-controls`, row IDs, the new Delete attributes) so a future template refactor can't silently break the JS contract.

## Context for reviewers

Alpine's docs flagged that adjusting tab order in pure markup is weird, so added a small JS module (`initDNSRecordTabOrder` in `domain-dns-record-content.js`) that intercepts Tab/Shift+Ta. Edit, first form field, form Delete, and the kebab — and splices the kebab in after the form Delete only while a form is open. Focus also jumps into the form's first input on Edit click so screen-reader users land inside the form they just opened.

The Delete link in the edit form had no `href` and no `tabindex`, so it wasn't focusable at all before this PR — that fix is included here since the ticket lists Delete.

## Setup
Available on dg.
1. Sign in and open a domain's **DNS records** page (`dns_hosting` flag must be on, Domain must be enrolled).
2. Add at least one record so the table has a row.
3. Tab from the page top until focus reaches the **Edit** button on a record. Press Enter/Space to open the form.
4. Tab through and confirm the order:
5. Edit → Name → Content → TTL → Comment → Cancel → Save → Delete → More options → next row's Edit`.
6. Shift+Tab from the kebab and confirm it walks back to the form's Delete (not the previous row).
7. Close the form (Cancel) hit enter on cancel to close the form. From Edit, Press Tab to get to the More Options (AC, tab order should go from Edit to More options"
8. AC also asks for an ANDI pass — please run the page to confirm the announced focus order matches the visual order.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide — N/A (no behavior changes that need docs)

#### Ensured code standards are met (Original Developer)

- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt — N/A (no dep changes)
- [x] Interactions with external systems are wrapped in try/except — N/A (no external calls)
- [x] Error handling exists for unusual or missing values (defensive `?.` chains around Alpine state and DOM lookups so the module no-ops on pages without the records table)


#### Validated user-facing changes (if applicable)

- [x] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [x] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [x] Checked different states (empty, one, some, error)
- [x] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
