### PR TITLE
#4954: Fix DNS record form content label/helptext not updating  [dg]

### DIFF
--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -170,32 +170,32 @@ export function initDynamicDNSRecordFormFields() {
 
         const selectedType = this.value;
         const info = config[selectedType];
-        const contentLabel = document.querySelector('label[for=id_content]');
-        const contentHelp = document.getElementById('id_content_helptext');
-        
-        // Getting and cloning the required field asterisk
-        const abbrElement = contentLabel?.querySelector('abbr');
-        const abbrClone = abbrElement ? abbrElement.cloneNode(true) : null;
-     
-        if (info) { 
-            contentLabel.textContent = info.label;
-            contentHelp && (contentHelp.textContent = info.help_text)
-        }
-       
-        if(selectedType == "TXT"){
-            // Swap input type to text area
-            // Utilized set time out for Firefox loading engine to grab the input after dom content loads
-            setTimeout(()=>{
-            let input = document.querySelector(".content-field-wrapper-txt input")
-            input && switchFromInputToTextArea(input)
-            }, 0)
-        }
-        
 
-        // Appending the asterisk to the label
-        contentLabel.appendChild(abbrClone);
+        // Defer to the next tick so Alpine.js has time to swap the form sub-template
+        // (x-if base/MX/TXT) before we query the freshly-mounted label and helptext.
+        // Without this, we update DOM nodes that are about to be removed, and the new
+        // template renders with the default server-rendered label/help text.
+        setTimeout(() => {
+            const contentLabel = document.querySelector('label[for=id_content]');
+            if (!contentLabel) return;
 
+            // Preserve the required field asterisk while overwriting label text
+            const abbrElement = contentLabel.querySelector('abbr');
+            const abbrClone = abbrElement ? abbrElement.cloneNode(true) : null;
 
+            if (info) {
+                contentLabel.textContent = info.label;
+                const contentHelp = document.getElementById('id_content_helptext');
+                if (contentHelp) contentHelp.textContent = info.help_text;
+            }
+
+            if (selectedType === "TXT") {
+                const input = document.querySelector(".content-field-wrapper-txt input");
+                if (input) switchFromInputToTextArea(input);
+            }
+
+            if (abbrClone) contentLabel.appendChild(abbrClone);
+        }, 0);
     });
     // Defensive edge case, if type is pre-selected (ex: submitting with errors)
     if (typeField.value) {

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -1,3 +1,5 @@
+import html as html_module
+import re
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -516,3 +518,39 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             self.assertContains(response, "You already entered this DNS record")
             self.assertNotContains(response, DNS_RECORD_PRIORITY_REQUIRED_ERROR_MESSAGE)
             svc.create_dns_record.assert_not_called()
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_add_record_form_renders_content_helptext_span(self):
+        """The add-record form's content field must render the helptext span server-side
+        so the JS handler can update its text when the type is changed (regression for #4954
+        - switching to/from MX or TXT must not strand the helper text)."""
+        response = self.client.get(self._url())
+        self.assertContains(response, 'id="id_content_helptext"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_add_record_form_type_config_includes_all_record_types(self):
+        """The type field's data-type-config drives the JS that updates the content
+        label/help text on type change. Regression for #4954: every record type — including
+        MX and TXT — must be present with its expected label and help_text."""
+        import json
+
+        response = self.client.get(self._url())
+        content = response.content.decode()
+
+        # Extract the data-type-config JSON value from the rendered type select
+        match = re.search(r'data-type-config="([^"]+)"', content)
+        self.assertIsNotNone(match, "data-type-config attribute missing from type select")
+        config = json.loads(html_module.unescape(match.group(1)))
+
+        for rt in DNSRecordTypes:
+            with self.subTest(record_type=rt.value):
+                self.assertIn(rt.value, config)
+                self.assertEqual(config[rt.value]["label"], rt.field_label)
+                self.assertEqual(config[rt.value]["help_text"], rt.help_text)
+
+        # MX and TXT are the regression targets — make sure they are explicitly present
+        self.assertIn("MX", config)
+        self.assertIn("TXT", config)
+        self.assertEqual(config["MX"]["help_text"], "Example: mail.example.gov")


### PR DESCRIPTION
## Ticket

Resolves #4954

## Changes

- Fixed the DNS record add form so the content field's label and example helper text update correctly when switching between record types
- Added regression tests for the type config and helper text rendering on the add record form

## Context for reviewers

The add record form swaps between base/MX/TXT sub-templates via Alpine.js `x-if`. The existing change handler ran synchronously and updated the old label/helptext nodes that Alpine was about to remove, so MX and TXT showed no helper text and switching back to A/AAAA/CNAME left the previous label stuck. Deferring the update with `setTimeout(..., 0)` lets Alpine finish swapping templates before we query and update the freshly-mounted DOM.

The new tests pin the `data-type-config` JSON contract that the JS reads, plus the presence of the `id_content_helptext` span in the initial render — so this regression can't sneak back in.

## Setup
Available on DG. Enrolled domain: [daisyepp.gov](https://getgov-dg.app.cloud.gov/domain/15075/dns/records)

1. Go to a [DNS Hosting enrolled domain's DNS records page](https://getgov-dg.app.cloud.gov/domain/15075/dns/records) and open the **Add record** form.
2. Change the **Type** field to A → confirm the content field shows the IPv4 label and `Example: 192.0.2.10` helper text.
3. Switch to MX → confirm the label updates to "Mail server" and helper text shows `Example: mail.example.gov`.
4. Switch to TXT → confirm the content field becomes a textarea with the correct label.
5. Switch back to A/AAAA/CNAME → confirm the label and helper text update each time.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)

- N/A If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- N/A Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- N/A Follow the process for requesting a design review
- N/A Verify new pages have been added to .pa11yci file
- [x] Checked keyboard navigability
- [x] Reviewed accessibility checklist using screen reader, ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool


### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [x] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
