### PR TITLE
Update omb_withdrawal_notification.txt, OMB -> you

### DIFF
--- a/src/registrar/templates/emails/omb_withdrawal_notification.txt
+++ b/src/registrar/templates/emails/omb_withdrawal_notification.txt
@@ -1,7 +1,7 @@
 {% autoescape off %}{# In a text file, we don't want to have HTML entities escaped #}
 Hi, OMB,
 
-The following .gov domain request has been withdrawn and no longer requires OMB review.
+The following .gov domain request has been withdrawn and no longer requires your review.
 
 DOMAIN REQUESTED: {{ domain_request.requested_domain.name }}
 REQUESTED BY: {{ domain_request.requester.email }}


### PR DESCRIPTION
This PR is for a single-word change for the OMB emails. We can use the second-person "you" instead of saying "OMB" again.