### PR TITLE
#4879: Fixes bug where error remains after correcting and saving DNS record form - [AD]

### DIFF
--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -2,7 +2,7 @@
 {% load custom_filters %}
 
 {# Inline edit form row for a DNS record. `record_id` is the record pk used for DOM targeting. #}
-<tr id="dnsrecord-edit-row-{{ record_id }}" x-show="showFormId == '{{ record_id }}'" class="hide-td-borders" {% if oob_swap %}hx-swap-oob="outerHTML"{% endif %}>
+<tr id="dnsrecord-edit-row-{{ record_id }}" x-show="showFormId == '{{ record_id }}'" class="hide-td-borders">
     <td colspan="5" class="no-padding-right">
         <div class="border radius-lg border-base-lighter padding-3">
             <form
@@ -11,7 +11,8 @@
                 class="usa-form usa-form--extra-large"
                 novalidate
                 hx-post="{% url 'domain-dns-records' domain.pk %}"
-                hx-swap="none"
+                hx-target="#dnsrecord-edit-form-{{ record_id }}"
+                {% if oob_swap %}hx-swap-oob="outerHTML"{% endif %}
             >
                 <h3 class="margin-top-0">Edit record</h3>
                 {% csrf_token %}

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -661,7 +661,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
                 {
                     "id": editing.id,
                     "type": "A",
-                    "name": "",
+                    "name": "@",
                     "content": "",
                     "ttl": 300,
                     "comment": "",
@@ -677,7 +677,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
                 {
                     "id": editing.id,
                     "type": "A",
-                    "name": "",
+                    "name": "@",
                     "content": "192.0.2.10",
                     "ttl": 300,
                     "comment": "",

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -639,3 +639,50 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
         self.assertIn("MX", config)
         self.assertIn("TXT", config)
         self.assertEqual(config["MX"]["help_text"], "Example: mail.example.gov")
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
+    def test_error_clears_after_posting_valid_data(self):
+        """Submitting invalid data via the edit form
+        and posting a new record clears the error field"""
+        # The record being edited
+        editing = create_dns_record(
+            self.dns_zone,
+            record_type="A",
+            record_name="mail",
+            record_content="192.0.2.20",
+            ttl=300,
+            x_record_id="x-editing",
+        )
+
+        with patch("registrar.views.domain.DnsHostService"):
+            response = self.client.post(
+                self._url(),
+                {
+                    "id": editing.id,
+                    "type": "A",
+                    "name": "",
+                    "content": "",
+                    "ttl": 300,
+                    "comment": "",
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "Enter a valid IPv4 address using numbers and periods.")
+
+        with patch("registrar.views.domain.DnsHostService"):
+            response = self.client.post(
+                self._url(),
+                {
+                    "id": editing.id,
+                    "type": "A",
+                    "name": "",
+                    "content": "192.0.2.10",
+                    "ttl": 300,
+                    "comment": "",
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, "Enter a valid IPv4 address using numbers and periods.")

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -646,16 +646,20 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
         """Submitting invalid data via the edit form
         and posting a new record clears the error field"""
         # The record being edited
+        record_type = DNSRecordTypes.A
         editing = create_dns_record(
             self.dns_zone,
-            record_type="A",
-            record_name="mail",
-            record_content="192.0.2.20",
+            record_type=record_type,
+            record_name="@",
+            record_content="192.0.2.1",
             ttl=300,
-            x_record_id="x-editing",
+            x_record_id="x-existing-a",
         )
 
-        with patch("registrar.views.domain.DnsHostService"):
+        with patch("registrar.views.domain.DnsHostService") as MockSvc:
+            svc = MockSvc.return_value
+            svc.get_x_zone_id_if_zone_exists.return_value = ("zone-123", ["ex1.dns.gov"])
+
             response = self.client.post(
                 self._url(),
                 {
@@ -669,20 +673,18 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "Enter a valid IPv4 address using numbers and periods.")
+            self.assertContains(response, DNSRecordTypes(record_type).error_message)
 
-        with patch("registrar.views.domain.DnsHostService"):
-            response = self.client.post(
+            response_too = self.client.post(
                 self._url(),
                 {
                     "id": editing.id,
-                    "type": "A",
                     "name": "@",
-                    "content": "192.0.2.10",
+                    "content": "192.0.2.1",
                     "ttl": 300,
                     "comment": "",
                 },
             )
 
-            self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, "Enter a valid IPv4 address using numbers and periods.")
+            self.assertEqual(response_too.status_code, 200)
+            self.assertNotContains(response_too, DNSRecordTypes(record_type).error_message)


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4879 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Moved the htmx swap from the row to the form, and added a hx target 

From the [htmx docs](https://htmx.org/docs/#troublesome-tables), table elements can cause issues with swapping. So I moved the swap from tr element down to the form element. And it has resolved the issue. 

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

1. Navigate to /admin -> domains table
2. Find "ive-happy-friend.gov" and hit manage.
3. Create an error on one of the edit forms within the table by leaving it blank or not using the suggested formatting in the help text.
4. Hit "Save".  You should get an inline error.
5. Add valid data to the form field with the inline error and hit "Save"
6. Open the same edit form, the inline errors should not display.


## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [x] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
