### PR TITLE
Regression testing with playwright

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+/screenshots/*
+/videos/*
+/__pycache__/*
+/.pytest_cache/*
+/notes/*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,91 @@
+# E2E Regression Tests
+
+Browser-level regression tests for manage.get.gov using [Playwright](https://playwright.dev/python/).
+
+## Why Playwright?
+
+- Real Chromium browser — tests what actual users see, including CSS, JS, and navigation
+- Built-in auto-wait (no `time.sleep()` hacks)
+- Works alongside Django's test suite without modifying it
+
+## Auth bypass
+
+Login.gov (OIDC) requires 2FA and cannot be automated locally. We use a **dev-only auto-login URL**
+(`/dev-auto-login/`) that:
+
+- Creates or reuses a test Django user for the requested persona
+- Logs them in via Django's session auth
+- Redirects to the target page
+
+**Safety guarantees:**
+- The view returns 404 unless `settings.ALLOW_AUTO_LOGIN = True`
+- `ALLOW_AUTO_LOGIN` is forced to `False` if `IS_PRODUCTION = False`
+- This protects it from being turned on in production, however, it also allows us to use the `ALLOW_AUTO_LOGIN` to gate some sandboxes from using this as well. For instance, if we don't want staging or product using e2e testing and messing with UAT testing items, we can turn `ALLOW_AUTO_LOGIN` off in that env. Meanwhile, IS_PRODUCTION will always remain false in any non prod env and shouldn't be altered.
+
+## Setup
+
+### 1. Start the app
+
+```bash
+cd src
+docker compose up -d
+```
+
+### 2. Install Python test dependencies (on your laptop, outside Docker)
+
+```bash
+cd e2e
+pip install -r requirements.txt
+playwright install chromium
+```
+
+## Running the tests
+
+### Run the entire suite
+
+```bash
+cd e2e
+pytest -v
+```
+
+### Run a single file
+
+```bash
+pytest test_profile_page.py -v
+```
+
+### Watch mode (visible browser)
+
+```bash
+pytest -v --headed
+```
+
+### Slow motion (useful for debugging)
+
+```bash
+pytest -v --headed --slowmo 1000
+```
+
+## Output
+
+- **Videos** — `e2e/videos/<test_name>.webm`, one per test, recorded regardless of pass/fail
+- **Screenshots** — `e2e/screenshots/FAILED_<test_name>.png`, saved only on failure
+
+## Test files
+
+| File | Personas | Scenarios |
+|---|---|---|
+| `test_profile_page.py` | generic | Profile page loads, no OIDC redirect, accessibility scan, form save |
+| `test_legacy_user.py` | legacy_user_1 | Full legacy experience: home, domain management, profile, domain request |
+| `test_portfolio_user_basic.py` | portfolio_user_2 | Home, manage domain, org access blocked, profile |
+| `test_portfolio_user_requester.py` | portfolio_user_requester_3 | Home, create domain request |
+| `test_org_admin.py` | org_admin_4 | Home, org page, member management |
+| `test_multi_portfolio.py` | multi_portfolio_admin_7 | Portfolio selector, switch portfolios, /your-organizations/ |
+| `test_mixed_permissions.py` | mixed_permissions_6 | Org experience, legacy domain access |
+| `test_navigation_footer.py` | portfolio_user_2, legacy_user_1, multi_portfolio_admin_7 | Header and footer link consistency |
+| `test_permission_ui.py` | portfolio_user_2, portfolio_user_requester_3, org_admin_4 | Role-based control visibility |
+| `test_session_management.py` | portfolio_user_requester_3, multi_portfolio_admin_7 | Session persistence, portfolio switch |
+| `test_error_handling.py` | legacy_user_1, portfolio_user_2 | 403 errors, read-only org page, unauthenticated access |
+| `test_django_admin.py` | django_admin_analyst_8 | Domain request workflow, search, filters, collapsible fieldsets |
+
+

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,141 @@
+"""Shared Playwright fixtures for get.gov E2E regression tests."""
+
+import logging
+import os
+import pytest
+from axe_playwright_python.sync_playwright import Axe
+
+from utils import BASE_URL, hide_debug_toolbar
+
+logger = logging.getLogger(__name__)
+
+AUTO_LOGIN_URL = f"{BASE_URL}/dev-auto-login/"
+SCREENSHOT_DIR = os.path.join(os.path.dirname(__file__), "screenshots")
+VIDEO_DIR = os.path.join(os.path.dirname(__file__), "videos")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_output_dirs():
+    """Create screenshots/ and videos/ output directories once per session."""
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+    os.makedirs(VIDEO_DIR, exist_ok=True)
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return BASE_URL
+
+
+@pytest.fixture
+def axe():
+    """Axe-core accessibility runner — inject and run against any Playwright page."""
+    return Axe()
+
+
+@pytest.fixture
+def authenticated_page(page):
+    """Return a Playwright page authenticated as the generic E2E test user."""
+    page.goto(f"{AUTO_LOGIN_URL}?persona=generic&next=/user-profile")
+    page.wait_for_load_state("networkidle")
+    return page
+
+
+def dev_auto_login(page, persona: str, next_path: str = "/"):
+    """Navigate through dev-auto-login for a named persona and fail if it is unavailable."""
+    login_url = f"{AUTO_LOGIN_URL}?persona={persona}&next={next_path}"
+    response = page.goto(login_url)
+    page.wait_for_load_state("networkidle")
+
+    if response is None:
+        pytest.fail(
+            f"Dev auto-login persona '{persona}' did not return a response. "
+            "Ensure /dev-auto-login/ is enabled and the test infrastructure supports this persona."
+        )
+
+    if response.status is not None and response.status >= 400:
+        pytest.fail(
+            f"Dev auto-login persona '{persona}' returned HTTP status {response.status}. "
+            "The dev-auto-login endpoint or persona configuration is broken."
+        )
+
+    if page.url.startswith(f"{BASE_URL}/openid/login") or page.url.startswith(f"{BASE_URL}/login"):
+        pytest.fail(
+            f"Dev auto-login persona '{persona}' redirected to login instead of bypassing auth. "
+            "The dev-auto-login bypass is not functioning for this persona."
+        )
+
+    if page.url.startswith(AUTO_LOGIN_URL):
+        pytest.fail(
+            f"Dev auto-login persona '{persona}' did not complete the redirect from the auto-login endpoint."
+        )
+
+    return page
+
+
+@pytest.fixture
+def video_page(browser, request):
+    """
+    Return a Playwright page configured for video recording.
+
+    The video is saved to videos/<test_name>.webm when the test finishes,
+    regardless of pass or fail. On failure, a screenshot is also saved by
+    the pytest_runtest_makereport hook below.
+
+    Each test is responsible for navigating to the appropriate persona URL
+    before interacting with the page.
+    """
+    context = browser.new_context(
+        record_video_dir=VIDEO_DIR,
+        record_video_size={"width": 1280, "height": 720},
+    )
+    page = context.new_page()
+
+    yield page
+
+    video = page.video
+    context.close()
+    if video:
+        try:
+            original_path = video.path()
+            safe_name = (
+                request.node.name
+                .replace("[", "_")
+                .replace("]", "")
+                .replace(" ", "_")
+            )
+            new_path = os.path.join(VIDEO_DIR, f"{safe_name}.webm")
+            os.rename(original_path, new_path)
+            logger.debug("Video saved: %s", new_path)
+        except Exception as exc:
+            logger.warning("Could not rename video: %s", exc)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Save a failure screenshot for any test that has a page or video_page fixture."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when != "call" or not report.failed:
+        return
+
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+    safe_name = (
+        item.name
+        .replace("[", "_")
+        .replace("]", "")
+        .replace(" ", "_")
+    )
+    path = os.path.join(SCREENSHOT_DIR, f"FAILED_{safe_name}.png")
+
+    pg = (
+        item.funcargs.get("video_page")
+        or item.funcargs.get("page")
+        or item.funcargs.get("authenticated_page")
+    )
+    if pg is not None:
+        try:
+            pg.screenshot(path=path, full_page=True)
+            logger.debug("Failure screenshot: %s", path)
+        except Exception as exc:
+            logger.warning("Could not take failure screenshot: %s", exc)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(levelname)-8s %(name)s: %(message)s

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,4 @@
+playwright>=1.43.0
+pytest-playwright>=0.5.0
+pytest>=8.0.0
+axe-playwright-python>=0.1.3

--- a/e2e/test_django_admin.py
+++ b/e2e/test_django_admin.py
@@ -1,0 +1,365 @@
+"""E2E regression tests: Django Admin Analyst Experience (User 8).
+
+User 8 setup (created by dev_auto_login persona=django_admin_analyst_8):
+  Email:    regressiontest+8@example.com
+  Role:     is_staff=True, is_superuser=True, cisa_analysts_group
+  Data:     Many domain requests (various statuses/org types) + approved domains
+
+Run:
+  cd e2e
+  pytest test_django_admin.py -v
+  pytest test_django_admin.py -v --headed
+  pytest test_django_admin.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, hide_debug_toolbar
+
+logger = logging.getLogger(__name__)
+
+WORKFLOW_REQUEST_NAME = "a8city1.gov"
+SEARCH_DOMAIN_NAME = "a8citya.gov"
+WAIT = 1_000
+
+
+class TestDjangoAdminAnalyst:
+    """Regression tests for the Django Admin Analyst experience (User 8)."""
+
+    _ADMIN_URL = f"{BASE_URL}/admin"
+    _DOMAIN_REQUESTS_URL = f"{BASE_URL}/admin/registrar/domainrequest/"
+    _DOMAINS_URL = f"{BASE_URL}/admin/registrar/domain/"
+    _DOMAIN_INFO_URL = f"{BASE_URL}/admin/registrar/domaininformation/"
+
+    @staticmethod
+    def _login(page, next_path="/admin/"):
+        dev_auto_login(page, "django_admin_analyst_8", next_path)
+
+    @staticmethod
+    def _nav(page, url):
+        """Navigate to a URL, wait for network idle, and hide the debug toolbar."""
+        page.goto(url)
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+    @staticmethod
+    def _search(page, term, list_url=None):
+        """Navigate directly to the admin list with a search query applied.
+
+        Navigating by URL is more reliable than typing in the search bar because
+        it avoids race conditions with the Django admin's AJAX-based filtering.
+        """
+        base = list_url or page.url.split("?")[0]
+        page.goto(f"{base.rstrip('/')}/?q={term}")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+    @staticmethod
+    def _click_filter(page, filter_text):
+        """Click a standard filter link in the #changelist-filter sidebar."""
+        link = page.locator("#changelist-filter a", has_text=filter_text).first
+        if link.is_visible():
+            link.click()
+            page.wait_for_load_state("networkidle")
+            hide_debug_toolbar(page)
+            page.wait_for_timeout(WAIT)
+            return True
+        return False
+
+    @staticmethod
+    def _click_checkbox_filter(page, filter_text):
+        """Click a MultipleChoiceListFilter checkbox-style link in the sidebar."""
+        panel = page.locator("#changelist-filter")
+        link = panel.locator("[role='menuitemcheckbox']", has_text=filter_text).first
+        if not link.is_visible():
+            link = panel.locator("a", has_text=filter_text).first
+        if link.is_visible():
+            link.click()
+            page.wait_for_load_state("networkidle")
+            hide_debug_toolbar(page)
+            page.wait_for_timeout(WAIT)
+            return True
+        return False
+
+    @staticmethod
+    def _reset_filters(page, list_url):
+        """Navigate back to the unfiltered list to clear active filter state."""
+        page.goto(list_url)
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+    def test_admin_domain_request_workflow(self, video_page):
+        """Domain request analyst workflow: assign investigator, set in review, approve.
+
+        Steps:
+          1. Login and navigate to the domain requests list.
+          2. Search for the target SUBMITTED request.
+          3. Open the detail page.
+          4. Click "Assign to me" to set self as investigator.
+          5. Click "Save and continue editing" to persist the investigator.
+          6. Select "In review" from the status dropdown (now available since investigator is set).
+          7. Click Save and verify success.
+          8. Re-open the request; verify status is "In review".
+          9. Change status to "Approved" and save.
+         10. Verify the domain now exists in the admin domain table.
+         11. Verify a domain information record also exists.
+        """
+        page = video_page
+        self._login(page)
+        page.wait_for_timeout(WAIT)
+
+        self._nav(page, self._DOMAIN_REQUESTS_URL)
+        self._search(page, WORKFLOW_REQUEST_NAME.replace(".gov", ""))
+
+        assert page.locator("a", has_text=WORKFLOW_REQUEST_NAME).first.is_visible(), (
+            f"Expected to find '{WORKFLOW_REQUEST_NAME}' in search results."
+        )
+
+        page.locator("a", has_text=WORKFLOW_REQUEST_NAME).first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        assert "change" in page.url or "domainrequest" in page.url, (
+            "Expected to be on the domain request detail page."
+        )
+
+        assign_btn = page.locator("#investigator__assign_self")
+        assert assign_btn.is_visible(), (
+            "'Assign to me' button should be visible for a superuser."
+        )
+        assign_btn.click()
+        page.wait_for_timeout(WAIT)
+
+        # Save and continue editing so the investigator persists in the DB
+        # and the page reloads — the status dropdown will then offer all transitions.
+        page.locator("[name='_continue']").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        # Select "In review" from the dropdown now that the investigator is set.
+        page.select_option("#id_status", "in review")
+        page.wait_for_timeout(WAIT)
+
+        page.locator("[name='_save']").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        page_content = page.content()
+        assert (
+            "was changed successfully" in page_content
+            or self._DOMAIN_REQUESTS_URL.rstrip("/") in page.url
+        ), "Expected success message or redirect after saving 'In review'."
+
+        # Re-open the request and verify the status shows "In review".
+        self._nav(page, self._DOMAIN_REQUESTS_URL)
+        self._search(page, WORKFLOW_REQUEST_NAME.replace(".gov", ""))
+
+        assert page.locator("a", has_text=WORKFLOW_REQUEST_NAME).first.is_visible(), (
+            f"Expected '{WORKFLOW_REQUEST_NAME}' to still appear after saving 'In review'."
+        )
+
+        row_text = page.locator("table#result_list tbody tr").first.text_content() or ""
+        assert "In review" in row_text or "in review" in row_text.lower(), (
+            f"Expected the row to show 'In review' status. Row: {row_text!r}"
+        )
+
+        page.locator("a", has_text=WORKFLOW_REQUEST_NAME).first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        assert "In review" in page.content() or "in review" in page.content(), (
+            "Expected the detail page to show 'In review' status."
+        )
+
+        # Change status to "Approved" and save.
+        page.select_option("#id_status", "approved")
+        page.wait_for_timeout(WAIT)
+
+        page.locator("[name='_save']").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        page_content = page.content()
+        assert (
+            "was changed successfully" in page_content
+            or self._DOMAIN_REQUESTS_URL.rstrip("/") in page.url
+        ), "Expected success message or redirect after approving the domain request."
+
+        # Verify the approved domain now exists in the domains table.
+        domain_name = WORKFLOW_REQUEST_NAME
+        self._search(page, domain_name.replace(".gov", ""), list_url=self._DOMAINS_URL)
+
+        first_row = page.locator("table#result_list tbody tr").first
+        assert first_row.is_visible(), (
+            f"Expected at least one row in the domains table after searching for '{domain_name}'."
+        )
+        assert page.locator("a", has_text=domain_name).first.is_visible(), (
+            f"Expected domain '{domain_name}' to appear in the domains table after approval."
+        )
+        logger.debug("Domain '%s' confirmed in domain table after approval.", domain_name)
+
+        # Verify domain information also exists for the approved domain.
+        self._search(page, domain_name.replace(".gov", ""), list_url=self._DOMAIN_INFO_URL)
+
+        first_row = page.locator("table#result_list tbody tr").first
+        assert first_row.is_visible(), (
+            f"Expected at least one row in domain information after searching for '{domain_name}'."
+        )
+        assert page.locator("a", has_text=domain_name).first.is_visible(), (
+            f"Expected domain information for '{domain_name}' to exist after approval."
+        )
+        logger.debug("Domain information for '%s' confirmed after approval.", domain_name)
+
+    def test_admin_domain_search(self, video_page):
+        """Domains table search by domain name."""
+        page = video_page
+        self._login(page)
+        page.wait_for_timeout(WAIT)
+
+        self._nav(page, self._DOMAINS_URL)
+        self._search(page, SEARCH_DOMAIN_NAME.replace(".gov", ""))
+
+        assert page.locator("a", has_text=SEARCH_DOMAIN_NAME).first.is_visible(), (
+            f"Expected to find domain '{SEARCH_DOMAIN_NAME}' in search results."
+        )
+        logger.debug("Domain search completed.")
+
+    def test_admin_domain_request_filters(self, video_page):
+        """Domain requests sidebar filters — exercises every filter option.
+
+        Covers status, generic org type, federal type, election office,
+        rejection reason, and investigator filters.
+        """
+        page = video_page
+        self._login(page)
+        page.wait_for_timeout(WAIT)
+
+        self._nav(page, self._DOMAIN_REQUESTS_URL)
+
+        # Status filters
+        for label in ["In review", "Action needed", "Approved", "Rejected",
+                      "Submitted", "Withdrawn", "Started"]:
+            self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+            self._click_checkbox_filter(page, label)
+            logger.debug("Domain request status filter '%s' applied.", label)
+
+        # Generic org type filters
+        for label in ["Federal", "City", "County", "State or territory",
+                      "Tribal", "School district", "Interstate", "Special district"]:
+            self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain request org type filter '%s' applied.", label)
+
+        # Federal type filters
+        for label in ["Executive", "Judicial", "Legislative"]:
+            self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain request federal type filter '%s' applied.", label)
+
+        # Election office filters
+        for label in ["Yes", "No"]:
+            self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain request election filter '%s' applied.", label)
+
+        # Rejection reason filters
+        for label in ["Purpose requirements not met", "Org not eligible for a .gov domain"]:
+            self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain request rejection filter '%s' applied.", label)
+
+        # Investigator filter
+        self._reset_filters(page, self._DOMAIN_REQUESTS_URL)
+        analyst_link = page.locator("#changelist-filter a", has_text="Analyst Eight").first
+        if analyst_link.is_visible():
+            analyst_link.click()
+            page.wait_for_load_state("networkidle")
+            hide_debug_toolbar(page)
+            page.wait_for_timeout(WAIT)
+            logger.debug("Domain request investigator filter applied.")
+
+        logger.debug("Domain request filters completed.")
+
+    def test_admin_domain_filters(self, video_page):
+        """Domain table sidebar filters — exercises org type, federal type, election, and state."""
+        page = video_page
+        self._login(page)
+        page.wait_for_timeout(WAIT)
+
+        self._nav(page, self._DOMAINS_URL)
+
+        # Generic org type filters
+        for label in ["Federal", "City", "County", "State or territory"]:
+            self._reset_filters(page, self._DOMAINS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain org type filter '%s' applied.", label)
+
+        # Federal type filters
+        for label in ["Executive", "Judicial"]:
+            self._reset_filters(page, self._DOMAINS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain federal type filter '%s' applied.", label)
+
+        # Election office filters
+        for label in ["Yes", "No"]:
+            self._reset_filters(page, self._DOMAINS_URL)
+            self._click_filter(page, label)
+            logger.debug("Domain election filter '%s' applied.", label)
+
+        # Domain state filters
+        for label in ["ready", "on hold", "unknown", "dns needed", "deleted"]:
+            self._reset_filters(page, self._DOMAINS_URL)
+            panel = page.locator("#changelist-filter")
+            link = panel.locator("a", has_text=label).first
+            if not link.is_visible():
+                link = panel.locator("a", has_text=label.title()).first
+            if link.is_visible():
+                link.click()
+                page.wait_for_load_state("networkidle")
+                hide_debug_toolbar(page)
+                page.wait_for_timeout(WAIT)
+                logger.debug("Domain state filter '%s' applied.", label)
+
+        logger.debug("Domain filters completed.")
+
+    def test_admin_domain_request_show_more(self, video_page):
+        """Collapsible fieldsets on the domain request detail page can all be expanded."""
+        page = video_page
+        self._login(page)
+        page.wait_for_timeout(WAIT)
+
+        self._nav(page, self._DOMAIN_REQUESTS_URL)
+        self._search(page, "a8county1")
+
+        assert page.locator("a", has_text="a8county1.gov").first.is_visible(), (
+            "Expected to find 'a8county1.gov' domain request."
+        )
+        page.locator("a", has_text="a8county1.gov").first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        page.wait_for_timeout(WAIT)
+
+        buttons = page.locator("fieldset.collapse--dgfieldset button")
+        btn_count = buttons.count()
+        assert btn_count > 0, (
+            f"Expected at least one 'Show details' button, found {btn_count}."
+        )
+
+        for i in range(btn_count):
+            btn = buttons.nth(i)
+            if btn.is_visible():
+                btn.click()
+                page.wait_for_timeout(WAIT)
+
+        assert "change" in page.url or "domainrequest" in page.url, (
+            "Expected to remain on the domain request detail page after expanding fieldsets."
+        )
+        logger.debug("Show details completed — all fieldsets expanded.")

--- a/e2e/test_error_handling.py
+++ b/e2e/test_error_handling.py
@@ -1,0 +1,94 @@
+"""E2E regression tests: Error Handling and Edge Cases.
+
+Run:
+  cd e2e
+  pytest test_error_handling.py -v
+  pytest test_error_handling.py -v --headed
+  pytest test_error_handling.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, assert_basic_header, assert_extended_header, hide_debug_toolbar
+
+logger = logging.getLogger(__name__)
+
+
+class TestErrorHandling:
+    """Regression tests for error handling and edge cases."""
+
+    @staticmethod
+    def _login_legacy(page, next_path="/"):
+        dev_auto_login(page, "legacy_user_1", next_path)
+
+    @staticmethod
+    def _login_basic(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_2", next_path)
+
+    def test_legacy_user_blocked_from_portfolio_pages(self, video_page):
+        """Legacy user is blocked from /organization/ with a 403 or redirect, and can navigate back."""
+        page = video_page
+        self._login_legacy(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        assert_basic_header(page)
+
+        page.goto(f"{BASE_URL}/organization/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        is_blocked = (
+            page.locator("h2", has_text="403").is_visible()
+            or page.locator("text=Access Denied").is_visible()
+            or page.locator("text=Forbidden").is_visible()
+            or page.locator("text=You do not have permission").is_visible()
+            or not page.url.startswith(f"{BASE_URL}/organization")
+        )
+        assert is_blocked, (
+            f"Legacy user should be blocked from /organization/. URL: {page.url}"
+        )
+
+        page.goto(f"{BASE_URL}/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.locator("h1").first.is_visible(), (
+            "User should be able to navigate back to home after being blocked."
+        )
+
+    def test_non_admin_sees_readonly_organization_page(self, video_page):
+        """Basic portfolio member sees the org page read-only (no Edit buttons)."""
+        page = video_page
+        self._login_basic(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        page.goto(f"{BASE_URL}/organization/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/organization") or page.locator("h1").first.is_visible(), (
+            "Basic member should be able to view the organization page."
+        )
+
+        assert_extended_header(page)
+
+        edit_button = page.locator("a.usa-button", has_text="Edit")
+        assert not edit_button.is_visible(), (
+            "Edit button should NOT be visible for basic members on the organization page."
+        )
+
+    def test_unauthenticated_access_redirects_to_login(self, video_page):
+        """Unauthenticated access to protected pages redirects away from the target URL."""
+        page = video_page
+
+        page.goto(f"{BASE_URL}/domains/")
+        page.wait_for_load_state("networkidle")
+        assert not page.url.startswith(f"{BASE_URL}/domains/"), (
+            "Unauthenticated user should not have access to /domains/."
+        )
+
+        page.goto(f"{BASE_URL}/members/")
+        page.wait_for_load_state("networkidle")
+        assert not page.url.startswith(f"{BASE_URL}/members/"), (
+            "Unauthenticated user should not have access to /members/."
+        )

--- a/e2e/test_legacy_user.py
+++ b/e2e/test_legacy_user.py
@@ -1,0 +1,304 @@
+"""E2E regression tests: Legacy User Full Experience.
+
+User 1 setup (created by dev_auto_login persona=legacy_user_1):
+  Email:    regressiontest+1@gmail.com
+  Domains:  donutdefenders.gov, alienoutpost.gov, alicornalliance.gov  (all READY)
+  Request:  sprinkledonut.gov  (SUBMITTED)
+
+Run:
+  cd e2e
+  pytest test_legacy_user.py -v
+  pytest test_legacy_user.py -v --headed
+  pytest test_legacy_user.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import (
+    BASE_URL,
+    assert_basic_footer,
+    assert_basic_header,
+    hide_debug_toolbar,
+    wait_for_table_rows,
+    continue_wizard_step,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestLegacyUserFullExperience:
+    """Single recorded end-to-end test for the Legacy User experience.
+
+    Executes all Suite 1 scenarios in one continuous session with video
+    recording for full click-and-navigation replay.
+    """
+
+    @staticmethod
+    def _login(page, next_path="/"):
+        dev_auto_login(page, "legacy_user_1", next_path)
+
+    @staticmethod
+    def _assert_no_org_in_header(page):
+        """The header must not display any organisation name."""
+        assert not page.locator(".usa-nav__org-name").is_visible(), (
+            "Org name should not be visible in the header for legacy users."
+        )
+
+    @staticmethod
+    def _assert_org_page_blocked(page):
+        """Assert organization page access is blocked by 403 or a redirect to home."""
+        if page.url.startswith(f"{BASE_URL}/your-organizations"):
+            assert (
+                page.locator("text=403").is_visible()
+                or page.locator("text=Access Denied").is_visible()
+                or page.locator("text=Forbidden").is_visible()
+            ), "Organization page should be blocked with 403-type messaging."
+        else:
+            assert page.url == f"{BASE_URL}/" or page.locator(
+                "h1", has_text="Manage your domains"
+            ).is_visible(), (
+                "Organization page access should block and redirect to home if 403 is not shown."
+            )
+
+    @staticmethod
+    def _fill_domain_request_form(page, requested_domain="newtestdomain"):
+        """Fill the domain request wizard for a city-type org.
+
+        Caller must already be on /request/start/. Uses the city org path (non-federal,
+        non-tribal). USWDS radio tiles use opacity:0 so dispatch_event bypasses visibility checks.
+        Django wizard prefixes all field names as <step_name>-<field_name>.
+        """
+        page.locator("button[name='submit_button'][value='intro_acknowledge']").click()
+        page.wait_for_load_state("networkidle")
+
+        page.locator(
+            "input[name='generic_org_type-generic_org_type'][value='city']"
+        ).dispatch_event("click")
+        continue_wizard_step(page)
+
+        page.locator(
+            "input[name='organization_election-is_election_board'][value='False']"
+        ).dispatch_event("click")
+        continue_wizard_step(page)
+
+        page.locator("input[name='organization_contact-organization_name']").fill("Test City Government")
+        page.locator("input[name='organization_contact-address_line1']").fill("123 Main Street")
+        page.locator("input[name='organization_contact-city']").fill("Testville")
+        page.locator("select[name='organization_contact-state_territory']").select_option("CA")
+        page.locator("input[name='organization_contact-zipcode']").fill("90210")
+        continue_wizard_step(page)
+
+        about_field = page.locator("textarea[name='about_your_organization-about_your_organization']")
+        if about_field.is_visible():
+            about_field.fill("A test city government providing essential municipal services.")
+            continue_wizard_step(page)
+
+        page.locator("input[name='senior_official-first_name']").fill("John")
+        page.locator("input[name='senior_official-last_name']").fill("Doe")
+        page.locator("input[name='senior_official-title']").fill("Mayor")
+        page.locator("input[name='senior_official-email']").fill("john.doe@testcity.gov")
+        continue_wizard_step(page)
+
+        if page.url.endswith("current_sites/"):
+            continue_wizard_step(page)
+
+        page.locator("input[name='dotgov_domain-requested_domain']").fill(requested_domain)
+        continue_wizard_step(page)
+
+        page.locator("textarea[name='purpose-purpose']").fill(
+            "E2E regression test domain request for automated testing purposes."
+        )
+        continue_wizard_step(page)
+
+        has_other = page.locator("input[name='other_contacts-has_other_contacts'][value='False']")
+        if has_other.count() > 0:
+            has_other.dispatch_event("click")
+            rationale = page.locator("textarea[name='other_contacts-no_other_contacts_rationale']")
+            rationale.wait_for(state="visible", timeout=5000)
+            rationale.fill("No other contacts are needed for this test request.")
+            continue_wizard_step(page)
+
+        cisa_rep = page.locator("input[name='additional_details-has_cisa_representative'][value='False']")
+        if cisa_rep.count() > 0:
+            cisa_rep.dispatch_event("click")
+        anything_else = page.locator("input[name='additional_details-has_anything_else_text'][value='False']")
+        if anything_else.count() > 0:
+            anything_else.dispatch_event("click")
+        if cisa_rep.count() > 0 or anything_else.count() > 0:
+            continue_wizard_step(page)
+
+        policy_checkbox = page.locator("input[name='requirements-is_policy_acknowledged']")
+        if policy_checkbox.count() > 0:
+            policy_checkbox.dispatch_event("click")
+            continue_wizard_step(page)
+
+        submit_link = page.locator("a[href='#toggle-submit-domain-request']")
+        if submit_link.is_visible():
+            submit_link.click()
+            page.wait_for_selector("#domain-request-form-submit-button", state="visible", timeout=5000)
+            page.locator("#domain-request-form-submit-button").click()
+            page.wait_for_load_state("networkidle")
+
+    def test_legacy_user_full_experience(self, video_page):
+        """Complete legacy user flow: home page, domain management, profile, and domain request.
+
+        Steps:
+          1.  Login and verify the legacy home page (domains + requests visible, single navbar).
+          2.  Manage donutdefenders.gov — verify senior official and security email tabs.
+          3.  Navigate to /your-organizations/ — verify access is blocked.
+          4.  Open profile page from the username dropdown.
+          5.  Return home and manage the sprinkledonut.gov domain request.
+          6.  Navigate to the create new domain request flow.
+          7.  Fill in all form steps and submit.
+          8.  Verify the confirmation page, then return home and confirm the new request appears.
+        """
+        page = video_page
+        hide_debug_toolbar(page)
+
+        self._login(page, next_path="/")
+
+        assert page.locator("h1", has_text="Manage your domains").is_visible(), (
+            "Expected 'Manage your domains' heading on the legacy home page."
+        )
+
+        wait_for_table_rows(page, "domains__table-wrapper")
+        domains_table = page.locator("#domains__table-wrapper tbody")
+        assert domains_table.locator("td", has_text="donutdefenders.gov").is_visible(), (
+            "donutdefenders.gov should be visible in the domains table."
+        )
+        assert domains_table.locator("td", has_text="alienoutpost.gov").is_visible(), (
+            "alienoutpost.gov should be visible in the domains table."
+        )
+        assert domains_table.locator("td", has_text="alicornalliance.gov").is_visible(), (
+            "alicornalliance.gov should be visible in the domains table."
+        )
+
+        wait_for_table_rows(page, "domain-requests__table-wrapper")
+        requests_table = page.locator("#domain-requests__table-wrapper tbody")
+        assert requests_table.locator("td", has_text="sprinkledonut.gov").is_visible(), (
+            "sprinkledonut.gov should be visible in the domain requests table."
+        )
+
+        assert_basic_header(page)
+        assert page.locator(".usa-nav__username").is_visible(), (
+            "User email should appear in the nav."
+        )
+        self._assert_no_org_in_header(page)
+        assert_basic_footer(page)
+
+        # Step 2: Manage donutdefenders.gov
+        page.locator("#domains__table-wrapper a", has_text="Manage").first.click()
+        page.wait_for_load_state("networkidle")
+
+        assert_basic_header(page)
+        assert page.locator(".usa-nav__username").is_visible(), (
+            "User email should still appear in the nav on the domain detail page."
+        )
+        assert page.locator("h3", has_text="Senior official").is_visible(), (
+            "Legacy domain detail page must display the 'Senior official' section."
+        )
+
+        page.get_by_role("link", name="Senior official", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        assert (
+            page.locator("input[name='first_name']").is_visible()
+            or page.locator("h1", has_text="Senior official").is_visible()
+        ), "Senior official details should be shown."
+
+        page.get_by_role("link", name="Security email", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        assert page.locator("input[name='security_email']").is_visible(), (
+            "Security email field should be present."
+        )
+
+        assert_basic_footer(page)
+
+        # Step 3: Navigate to /your-organizations/ and verify access is blocked
+        page.goto(f"{BASE_URL}/your-organizations/")
+        page.wait_for_load_state("networkidle")
+
+        self._assert_org_page_blocked(page)
+        assert_basic_footer(page)
+
+        # Step 4: Open the profile page from the username dropdown
+        page.goto(f"{BASE_URL}/")
+        wait_for_table_rows(page, "domains__table-wrapper")
+
+        page.locator(".usa-nav__username").click()
+        page.get_by_label("Primary navigation").get_by_role(
+            "link", name="Your profile"
+        ).first.click()
+        page.wait_for_load_state("networkidle")
+
+        assert (
+            page.locator("h1", has_text="Your profile").is_visible()
+            or page.locator("text=Your profile").is_visible()
+        ), "Profile page should load."
+
+        assert_basic_header(page)
+        self._assert_no_org_in_header(page)
+
+        email_field = page.locator("input[name='email']")
+        if email_field.is_visible():
+            assert (
+                email_field.get_attribute("readonly") is not None
+                or email_field.get_attribute("disabled") is not None
+            ), "Email field should be readonly or disabled."
+
+        assert_basic_footer(page)
+
+        # Step 5: Return home and manage the sprinkledonut.gov domain request
+        page.goto(f"{BASE_URL}/")
+        wait_for_table_rows(page, "domain-requests__table-wrapper")
+
+        page.locator("#domain-requests__table-wrapper a", has_text="Manage").first.click()
+        page.wait_for_load_state("networkidle")
+
+        assert (
+            page.locator("h1", has_text="Domain request").is_visible()
+            or page.locator("text=Domain request").is_visible()
+        ), "Domain request summary page should load."
+
+        assert_basic_header(page)
+        self._assert_no_org_in_header(page)
+        assert_basic_footer(page)
+
+        # Step 6: Navigate to the create new domain request flow
+        page.goto(f"{BASE_URL}/request/start/")
+        page.wait_for_load_state("networkidle")
+
+        assert page.locator("form").is_visible(), (
+            "Domain request intro form should be visible at /request/start/."
+        )
+        assert_basic_header(page)
+        self._assert_no_org_in_header(page)
+        assert_basic_footer(page)
+
+        # Step 7: Fill in all wizard steps and submit
+        requested_domain = "newtestdomain"
+        self._fill_domain_request_form(page, requested_domain)
+
+        # Step 8: Verify confirmation page and check new request on home
+        assert (
+            page.locator("h1", has_text="Thanks for your domain request!").is_visible()
+            or page.locator("text=Thanks for your domain request").is_visible()
+        ), "Should show 'Thanks for your domain request!' after submitting."
+
+        status_link = page.get_by_role("link", name="check the status")
+        if status_link.is_visible():
+            status_link.click()
+        else:
+            page.goto(f"{BASE_URL}/")
+        page.wait_for_load_state("networkidle")
+
+        wait_for_table_rows(page, "domain-requests__table-wrapper")
+        requests_table = page.locator("#domain-requests__table-wrapper tbody")
+        assert requests_table.locator("td", has_text=requested_domain).first.is_visible(), (
+            f"New request '{requested_domain}' should be visible in the domain requests table."
+        )
+        assert requests_table.locator("td", has_text="Submitted").first.is_visible(), (
+            "New request should have status 'Submitted'."
+        )
+
+        logger.debug("Legacy user full experience completed.")

--- a/e2e/test_mixed_permissions.py
+++ b/e2e/test_mixed_permissions.py
@@ -1,0 +1,101 @@
+"""E2E regression tests: Mixed Permission User (User 6).
+
+User 6 setup (created by dev_auto_login persona=mixed_permissions_6):
+  Email:    regressiontest+6@gmail.com
+  Role:     Org admin in 1 portfolio + domain manager on non-portfolio domain
+  Portfolio: 1 portfolio
+  Permissions: Portfolio admin + legacy domain management
+  Assigned Domains: 1 portfolio domain + 1 legacy domain (legacy6.gov)
+
+Run:
+  cd e2e
+  pytest test_mixed_permissions.py -v
+  pytest test_mixed_permissions.py -v --headed
+  pytest test_mixed_permissions.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, assert_extended_header, hide_debug_toolbar, wait_for_table_rows
+
+logger = logging.getLogger(__name__)
+
+
+class TestMixedPermissions:
+    """Regression tests for the mixed permission user (User 6)."""
+
+    @staticmethod
+    def _login(page, next_path="/"):
+        dev_auto_login(page, "mixed_permissions_6", next_path)
+
+    def test_user_6_organization_experience(self, video_page):
+        """User 6 can access portfolio home, org page, and member management."""
+        page = video_page
+        self._login(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Should be directed to the portfolio home page."
+        )
+
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should be visible in the navbar."
+        )
+
+        page.goto(f"{BASE_URL}/organization/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/organization") or page.locator("h1").first.is_visible(), (
+            "Organization page should load."
+        )
+        assert_extended_header(page)
+
+        nav = page.get_by_label("Primary navigation")
+        nav.get_by_role("link", name="Members", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/members") or page.locator("h1").first.is_visible(), (
+            "Members page should load."
+        )
+
+        try:
+            page.wait_for_selector("#members__table-wrapper tbody tr", timeout=15_000)
+            assert page.locator("#members__table-wrapper tbody tr").count() > 0, (
+                "Members table should have at least one row."
+            )
+        except Exception:
+            assert page.locator("table tbody tr").count() > 0, (
+                "Members table should have rows."
+            )
+
+        add_button = page.locator("a", has_text="Add a new member").or_(
+            page.locator("button", has_text="Add a new member")
+        )
+        assert add_button.is_visible(), (
+            "Add a new member button should be visible for org admin."
+        )
+
+    def test_user_6_legacy_domain_access(self, video_page):
+        """User 6 can see and manage portfolio domains with the extended header."""
+        page = video_page
+        self._login(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        wait_for_table_rows(page, "domains__table-wrapper")
+        assert page.locator("#domains__table-wrapper tbody tr").count() > 0, (
+            "Portfolio domains should be visible."
+        )
+        assert_extended_header(page)
+
+        page.locator("#domains__table-wrapper a", has_text="Manage").first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Portfolio domain should show org name in navbar."
+        )

--- a/e2e/test_multi_portfolio.py
+++ b/e2e/test_multi_portfolio.py
@@ -1,0 +1,117 @@
+"""E2E regression tests: Multi-Portfolio Admin Experience (User 7).
+
+User 7 setup (created by dev_auto_login persona=multi_portfolio_admin_7):
+  Email:    regressiontest+7@gmail.com
+  Role:     Organization admin in 2 different portfolios
+  Portfolios: 2 portfolios (Test Portfolio 7A, Test Portfolio 7B)
+  Note: multiple_portfolios waffle flag is enabled by the persona factory
+
+Run:
+  cd e2e
+  pytest test_multi_portfolio.py -v
+  pytest test_multi_portfolio.py -v --headed
+  pytest test_multi_portfolio.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, assert_extended_header, hide_debug_toolbar, select_portfolio
+
+logger = logging.getLogger(__name__)
+
+
+class TestMultiPortfolioAdmin:
+    """Regression tests for the multi-portfolio admin experience (User 7)."""
+
+    @staticmethod
+    def _login(page, next_path="/"):
+        dev_auto_login(page, "multi_portfolio_admin_7", next_path)
+
+    def test_multi_portfolio_user_portfolio_selector(self, video_page):
+        """Login presents the portfolio selector, and selecting one lands on the portfolio home."""
+        page = video_page
+        self._login(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        assert (
+            page.url.startswith(f"{BASE_URL}/your-organizations")
+            or page.locator("h1", has_text="Your organizations").is_visible()
+        ), "Portfolio selection page (/your-organizations/) should be displayed."
+
+        portfolio_buttons = page.locator("button.usa-card__container")
+        assert portfolio_buttons.count() >= 2, (
+            "At least 2 portfolio buttons should be listed on the selection page."
+        )
+
+        select_portfolio(page, index=0)
+
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Should be on the portfolio home page after selection."
+        )
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should be visible in the nav after selecting a portfolio."
+        )
+
+    def test_multi_portfolio_user_switch_between_portfolios(self, video_page):
+        """Switching portfolios via the Organizations dropdown updates the org name."""
+        page = video_page
+        self._login(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        select_portfolio(page, index=0)
+        first_org_name = page.locator(".organization-nav-link").first.text_content().strip()
+
+        orgs_button = page.locator("button#organizations-menu").first
+        assert orgs_button.is_visible(), (
+            "Organizations dropdown button should be visible for multi-portfolio users."
+        )
+
+        orgs_button.click()
+        page.wait_for_selector("#organizations-submenu", state="visible", timeout=5_000)
+        hide_debug_toolbar(page)
+
+        submenu_buttons = page.locator("#organizations-submenu button.organization-button")
+        assert submenu_buttons.count() >= 2, (
+            "Both portfolios should appear in the organizations dropdown."
+        )
+
+        submenu_buttons.nth(1).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        second_org_name = page.locator(".organization-nav-link").first.text_content().strip()
+        assert second_org_name != first_org_name, (
+            f"Org name should change after switching. Got '{second_org_name}' vs '{first_org_name}'"
+        )
+        assert_extended_header(page)
+
+    def test_multi_portfolio_admin_your_organizations_page(self, video_page):
+        """After selecting a portfolio, /your-organizations/ still lists all portfolios."""
+        page = video_page
+        self._login(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        select_portfolio(page, index=0)
+        hide_debug_toolbar(page)
+
+        page.goto(f"{BASE_URL}/your-organizations/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.locator("h1", has_text="Your organizations").is_visible(), (
+            "/your-organizations/ should show the 'Your organizations' heading."
+        )
+
+        portfolio_buttons = page.locator("button.usa-card__container")
+        assert portfolio_buttons.count() >= 2, (
+            "Both portfolios should be listed on /your-organizations/."
+        )
+
+        select_portfolio(page, index=1)
+
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Should land on the portfolio home after selecting from /your-organizations/."
+        )
+        assert_extended_header(page)

--- a/e2e/test_navigation_footer.py
+++ b/e2e/test_navigation_footer.py
@@ -1,0 +1,184 @@
+"""E2E regression tests: Navigation and Footer Link Consistency.
+
+Run:
+  cd e2e
+  pytest test_navigation_footer.py -v
+  pytest test_navigation_footer.py -v --headed
+  pytest test_navigation_footer.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import (
+    BASE_URL,
+    assert_basic_footer,
+    assert_basic_header,
+    assert_extended_header,
+    assert_portfolio_footer,
+    hide_debug_toolbar,
+    select_portfolio,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestNavigationFooter:
+    """Regression tests for navigation and footer link consistency."""
+
+    @staticmethod
+    def _login_portfolio(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_2", next_path)
+
+    @staticmethod
+    def _login_legacy(page, next_path="/"):
+        dev_auto_login(page, "legacy_user_1", next_path)
+
+    @staticmethod
+    def _login_multi_portfolio(page, next_path="/"):
+        dev_auto_login(page, "multi_portfolio_admin_7", next_path)
+
+    def test_portfolio_user_header_navigation(self, video_page):
+        """All secondary navbar links load the correct pages and maintain the dual navbar."""
+        page = video_page
+        self._login_portfolio(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        nav = page.get_by_label("Primary navigation")
+
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Domains page should load."
+        )
+        assert_extended_header(page)
+
+        nav.get_by_role("link", name="Domain requests", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/requests/") or page.locator("h1").first.is_visible(), (
+            "Domain requests page should load."
+        )
+        assert_extended_header(page)
+
+        page.goto(f"{BASE_URL}/organization/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/organization") or page.locator("h1").first.is_visible(), (
+            "Organization page should load."
+        )
+        assert_extended_header(page)
+
+    def test_portfolio_user_footer_navigation(self, video_page):
+        """All footer links load the correct pages and maintain the navbar structure."""
+        page = video_page
+        self._login_portfolio(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        page.locator(".usa-footer__address a", has_text="Domains").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Domains page should load from footer."
+        )
+        assert_extended_header(page)
+
+        page.locator(".usa-footer__address a", has_text="Domain requests").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/requests/") or page.locator("h1").first.is_visible(), (
+            "Domain requests page should load from footer."
+        )
+        assert_extended_header(page)
+
+        page.locator(".usa-footer__address a", has_text="Organization").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/organization") or page.locator("h1").first.is_visible(), (
+            "Organization page should load from footer."
+        )
+        assert_extended_header(page)
+
+        page.locator(".usa-footer__address a", has_text="Your profile").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/user-profile") or page.locator("h1").first.is_visible(), (
+            "Profile page should load from footer."
+        )
+        assert_extended_header(page)
+
+    def test_legacy_user_navigation_constraints(self, video_page):
+        """Legacy user sees only Home and Your profile in the footer, single navbar throughout."""
+        page = video_page
+        self._login_legacy(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        assert_basic_header(page)
+        assert_basic_footer(page)
+
+        footer = page.locator(".usa-footer__address")
+        assert not footer.locator("a", has_text="Domains").is_visible(), (
+            "No Domains link in legacy footer."
+        )
+        assert not footer.locator("a", has_text="Domain requests").is_visible(), (
+            "No Domain requests link in legacy footer."
+        )
+        assert not footer.locator("a", has_text="Organization").is_visible(), (
+            "No Organization link in legacy footer."
+        )
+
+        page.locator(".usa-nav__username").click()
+        hide_debug_toolbar(page)
+        page.get_by_label("Primary navigation").get_by_role(
+            "link", name="Your profile"
+        ).first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert_basic_header(page)
+        assert_basic_footer(page)
+
+    def test_cross_portfolio_admin_navigation(self, video_page):
+        """Switching portfolios updates the org name and all nav links remain functional."""
+        page = video_page
+        self._login_multi_portfolio(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        page.locator("button.usa-card__container").first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        first_org_name = page.locator(".organization-nav-link").first.text_content().strip()
+
+        nav = page.get_by_label("Primary navigation")
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Domains page should load."
+        )
+        assert page.locator(".organization-nav-link").first.text_content().strip() == first_org_name, (
+            "Org name should remain consistent within the first portfolio."
+        )
+
+        orgs_button = page.locator("button#organizations-menu").first
+        orgs_button.click()
+        page.wait_for_selector("#organizations-submenu", state="visible", timeout=5_000)
+        hide_debug_toolbar(page)
+
+        page.locator("#organizations-submenu button.organization-button").nth(1).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        second_org_name = page.locator(".organization-nav-link").first.text_content().strip()
+        assert second_org_name != first_org_name, (
+            "Org name should change after switching portfolios."
+        )
+
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Domains page should load in the second portfolio context."
+        )

--- a/e2e/test_org_admin.py
+++ b/e2e/test_org_admin.py
@@ -1,0 +1,132 @@
+"""E2E regression tests: Organization Admin Experience (User 4).
+
+User 4 setup (created by dev_auto_login persona=org_admin_4):
+  Email:    regressiontest+4@gmail.com
+  Role:     Organization admin
+  Portfolio: 1 portfolio
+  Permissions: Can manage portfolio members, view all domains/requests
+  Assigned Domains: None (portfolio must have domains and domain requests)
+
+Run:
+  cd e2e
+  pytest test_org_admin.py -v
+  pytest test_org_admin.py -v --headed
+  pytest test_org_admin.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import (
+    BASE_URL,
+    assert_extended_header,
+    assert_portfolio_footer,
+    hide_debug_toolbar,
+    wait_for_table_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestOrgAdmin:
+    """Regression tests for the Organization Admin experience (User 4)."""
+
+    @staticmethod
+    def _login(page, next_path="/"):
+        dev_auto_login(page, "org_admin_4", next_path)
+
+    def test_org_admin_home_page_display(self, video_page):
+        """Org admin lands on the portfolio home with domains, requests, and Members link visible."""
+        page = video_page
+        self._login(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Expected portfolio home page."
+        )
+
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should be visible in the navbar."
+        )
+
+        nav = page.get_by_label("Primary navigation")
+        assert nav.get_by_role("link", name="Members", exact=True).is_visible(), (
+            "Members link should be visible for org admin."
+        )
+
+        # Navigate to Domain Requests
+        requests_link = nav.get_by_role("link", name="Domain requests", exact=True)
+        requests_button = nav.get_by_role("button", name="Domain requests")
+        if requests_button.is_visible():
+            requests_button.click()
+        else:
+            requests_link.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        if not page.url.startswith(f"{BASE_URL}/requests/"):
+            page.get_by_role("link", name="Domain requests").first.click()
+            page.wait_for_load_state("networkidle")
+            hide_debug_toolbar(page)
+
+        wait_for_table_rows(page, "domain-requests__table-wrapper")
+        assert page.locator("#domain-requests__table-wrapper tbody tr").count() > 0, (
+            "Portfolio domain requests should be visible to org admin."
+        )
+
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        wait_for_table_rows(page, "domains__table-wrapper")
+        assert page.locator("#domains__table-wrapper tbody tr").count() > 0, (
+            "Portfolio domains should be visible to org admin."
+        )
+
+    def test_org_admin_access_to_organization_page(self, video_page):
+        """Org admin can load /organization/ successfully (not 403)."""
+        page = video_page
+        self._login(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        page.goto(f"{BASE_URL}/organization/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/organization") or page.locator("h1").first.is_visible(), (
+            "Organization overview page should load."
+        )
+        assert_extended_header(page)
+
+    def test_org_admin_manage_members(self, video_page):
+        """Org admin can reach the members page and sees the Add a new member button."""
+        page = video_page
+        self._login(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        nav = page.get_by_label("Primary navigation")
+        nav.get_by_role("link", name="Members", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.url.startswith(f"{BASE_URL}/members") or page.locator("h1").first.is_visible(), (
+            "Member management page should load."
+        )
+        assert_extended_header(page)
+
+        try:
+            page.wait_for_selector("#members__table-wrapper tbody tr", timeout=15_000)
+            assert page.locator("#members__table-wrapper tbody tr").count() > 0, (
+                "Member list should display."
+            )
+        except Exception:
+            assert page.locator("table tbody tr").count() > 0, (
+                "Member list should display."
+            )
+
+        add_member_button = page.locator("a", has_text="Add a new member").or_(
+            page.locator("button", has_text="Add a new member")
+        )
+        assert add_member_button.is_visible(), (
+            "Add a new member button should be visible for org admin."
+        )

--- a/e2e/test_permission_ui.py
+++ b/e2e/test_permission_ui.py
@@ -1,0 +1,110 @@
+"""E2E regression tests: Permission-Based UI Rendering.
+
+Run:
+  cd e2e
+  pytest test_permission_ui.py -v
+  pytest test_permission_ui.py -v --headed
+  pytest test_permission_ui.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, assert_extended_header, hide_debug_toolbar
+
+logger = logging.getLogger(__name__)
+
+
+class TestPermissionUI:
+    """Regression tests for permission-based UI rendering."""
+
+    @staticmethod
+    def _login_basic(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_2", next_path)
+
+    @staticmethod
+    def _login_requester(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_requester_3", next_path)
+
+    @staticmethod
+    def _login_admin(page, next_path="/domains/"):
+        dev_auto_login(page, "org_admin_4", next_path)
+
+    def test_basic_member_cannot_see_admin_controls(self, video_page):
+        """Basic member does not see the Members link or Settings, but does see Domains and Requests."""
+        page = video_page
+        self._login_basic(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        nav = page.get_by_label("Primary navigation")
+
+        assert not nav.get_by_role("link", name="Members", exact=True).is_visible(), (
+            "Members link should NOT be visible for basic members."
+        )
+        assert not page.locator("a", has_text="Settings").is_visible(), (
+            "Settings should not be accessible for basic members."
+        )
+        assert nav.get_by_role("link", name="Domains", exact=True).is_visible(), (
+            "Domains link should be visible."
+        )
+        assert nav.get_by_role("link", name="Domain requests", exact=True).is_visible(), (
+            "Domain requests link should be visible."
+        )
+
+    def test_admin_can_see_admin_controls(self, video_page):
+        """Org admin sees the Members link and the Add a new member button on the members page."""
+        page = video_page
+        self._login_admin(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        nav = page.get_by_label("Primary navigation")
+        assert nav.get_by_role("link", name="Members", exact=True).is_visible(), (
+            "Members link should be visible for org admin."
+        )
+
+        nav.get_by_role("link", name="Members", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.url.startswith(f"{BASE_URL}/members") or page.locator("h1").first.is_visible(), (
+            "Member management page should load."
+        )
+
+        add_member = page.locator("a", has_text="Add a new member").or_(
+            page.locator("button", has_text="Add a new member")
+        )
+        assert add_member.is_visible(), (
+            "Add a new member control should be visible for admin."
+        )
+
+    def test_requester_can_start_domain_request(self, video_page):
+        """Requester sees the Start a new domain request button; basic member does not."""
+        page = video_page
+
+        # User 3 (requester)
+        self._login_requester(page, next_path="/requests/")
+        hide_debug_toolbar(page)
+
+        start_button = page.locator("button", has_text="Start a new domain request")
+        assert start_button.is_visible(), (
+            "Start a new domain request should be visible for users with requester permissions."
+        )
+
+        page.goto(f"{BASE_URL}/request/start/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.locator("form").is_visible(), (
+            "Domain request form should load for requesters."
+        )
+
+        # User 2 (basic member, no EDIT_REQUESTS)
+        self._login_basic(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        page.goto(f"{BASE_URL}/no-organization-requests/")
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        start_button_basic = page.locator("button", has_text="Start a new domain request")
+        assert not start_button_basic.is_visible(), (
+            "Start a new domain request should NOT be visible for non-requester users."
+        )

--- a/e2e/test_portfolio_user_basic.py
+++ b/e2e/test_portfolio_user_basic.py
@@ -1,0 +1,193 @@
+"""E2E regression tests: Portfolio User Basic Experience (User 2).
+
+User 2 setup (created by dev_auto_login persona=portfolio_user_2):
+  Email:    regressiontest+2@gmail.com
+  Role:     Basic member - domain manager
+  Portfolio: 1 portfolio
+  Permissions: Portfolio permissions only (no requester or admin privileges)
+  Assigned Domains: At least 1 domain in portfolio
+
+Run:
+  cd e2e
+  pytest test_portfolio_user_basic.py -v
+  pytest test_portfolio_user_basic.py -v --headed
+  pytest test_portfolio_user_basic.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import (
+    BASE_URL,
+    assert_extended_header,
+    assert_portfolio_footer,
+    hide_debug_toolbar,
+    wait_for_table_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestPortfolioUserBasic:
+    """Regression tests for the basic portfolio user experience (User 2)."""
+
+    @staticmethod
+    def _login(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_2", next_path)
+
+    @staticmethod
+    def _assert_org_page_blocked(page):
+        """Assert /your-organizations/ is blocked by 403 or redirects away."""
+        if page.url.startswith(f"{BASE_URL}/your-organizations"):
+            assert (
+                page.locator("text=403").is_visible()
+                or page.locator("text=Access Denied").is_visible()
+                or page.locator("text=Forbidden").is_visible()
+            ), "Organization page should be blocked with 403-type messaging."
+        else:
+            allowed = [f"{BASE_URL}/", f"{BASE_URL}/domains/"]
+            assert any(page.url.startswith(r) for r in allowed), (
+                f"Organization page access should redirect away. Got: {page.url}"
+            )
+
+    def test_portfolio_user_home_page_display_and_no_requests_access(self, video_page):
+        """Portfolio home shows dual navbar, domains table, org name, and the correct footer."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/domains/")
+
+        assert (
+            page.locator("h1", has_text="Manage your domains").is_visible()
+            or page.locator("h1", has_text="Domains").is_visible()
+        ), "Expected a domains heading on the portfolio home page."
+
+        wait_for_table_rows(page, "domains__table-wrapper")
+        assert page.locator("#domains__table-wrapper").is_visible(), (
+            "Domains table wrapper should be visible."
+        )
+
+        assert_extended_header(page)
+        assert page.locator(".usa-nav__username").is_visible(), (
+            "User email should appear in the top nav."
+        )
+        assert page.locator("div.usa-nav__secondary").is_visible(), (
+            "Secondary navbar should be visible."
+        )
+
+        nav = page.get_by_label("Primary navigation")
+        assert nav.get_by_role("link", name="Domains", exact=True).is_visible(), (
+            "Domains tab should be visible."
+        )
+        assert nav.get_by_role("link", name="Domain requests", exact=True).is_visible(), (
+            "Domain requests tab should be visible."
+        )
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should appear in the secondary navbar."
+        )
+
+        assert_portfolio_footer(page)
+
+        assert not page.locator("a", has_text="Manage members").is_visible(), (
+            "Manage members should NOT be visible for basic members."
+        )
+
+        # Click Domain Requests tab — basic member has no requester permissions
+        page.get_by_role("link", name="Domain requests", exact=True).first.click()
+        page.wait_for_load_state("networkidle")
+
+        if page.locator("text=Access Denied").is_visible() or page.locator("text=403").is_visible():
+            pass  # expected — no requester permissions
+        else:
+            assert not page.locator("button", has_text="Create New Request").is_visible(), (
+                "Create New Request should NOT be visible for non-requester users."
+            )
+
+    def test_portfolio_user_manage_domain(self, video_page):
+        """Managing a domain shows the dual navbar, no Senior Official details, and the full footer."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/domains/")
+        wait_for_table_rows(page, "domains__table-wrapper")
+
+        page.locator("#domains__table-wrapper a", has_text="Manage").first.click()
+        page.wait_for_load_state("networkidle")
+
+        assert (
+            page.locator("h1", has_text="Domain").is_visible()
+            or page.locator("text=Domain").is_visible()
+        ), "Domain management page should load."
+
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should remain in the navbar."
+        )
+
+        assert not page.locator("h3", has_text="Senior official").is_visible(), (
+            "Senior official section should NOT be visible on portfolio domain pages."
+        )
+
+        suborg_field = page.locator("input[name='suborganization']")
+        if suborg_field.is_visible():
+            assert (
+                suborg_field.get_attribute("readonly") is not None
+                or suborg_field.get_attribute("disabled") is not None
+            ), "Suborganization field should be read-only for basic members."
+
+        assert_portfolio_footer(page)
+
+    def test_portfolio_user_cannot_access_organization_page(self, video_page):
+        """Navigating to /your-organizations/ is blocked; nav links still work afterward."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/domains/")
+
+        response = page.goto(f"{BASE_URL}/your-organizations/")
+        page.wait_for_load_state("networkidle")
+
+        if response is not None and response.status == 302 and page.url.startswith(
+            f"{BASE_URL}/openid/login/"
+        ):
+            pytest.fail("Auto-login did not create a valid portfolio session.")
+
+        self._assert_org_page_blocked(page)
+        assert_extended_header(page)
+
+        domains_link = page.get_by_label("Primary navigation").get_by_role(
+            "link", name="Domains", exact=True
+        )
+        domains_link.click()
+        page.wait_for_load_state("networkidle")
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Should be able to navigate back to the domains page."
+        )
+
+    def test_portfolio_user_profile_page(self, video_page):
+        """Profile page shows the dual navbar and has email as readonly."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/domains/")
+
+        page.locator(".usa-nav__username").click()
+        page.get_by_label("Primary navigation").get_by_role(
+            "link", name="Your profile"
+        ).first.click()
+        page.wait_for_load_state("networkidle")
+
+        assert (
+            page.locator("h1", has_text="Your profile").is_visible()
+            or page.locator("text=Your profile").is_visible()
+        ), "Profile editing page should load."
+
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").is_visible(), (
+            "Organization name should be visible in the navbar."
+        )
+
+        email_field = page.locator("input[name='email']")
+        if email_field.is_visible():
+            assert (
+                email_field.get_attribute("readonly") is not None
+                or email_field.get_attribute("disabled") is not None
+            ), "Email field should be readonly or disabled."
+
+        assert_portfolio_footer(page)

--- a/e2e/test_portfolio_user_requester.py
+++ b/e2e/test_portfolio_user_requester.py
@@ -1,0 +1,154 @@
+"""E2E regression tests: Portfolio User with Requester Permissions (User 3).
+
+User 3 setup (created by dev_auto_login persona=portfolio_user_requester_3):
+  Email:    regressiontest+3@gmail.com
+  Role:     Basic member - domain manager and requester
+  Portfolio: 1 portfolio
+  Permissions: Can view domains and make requests
+  Assigned Domains: At least 1 domain in portfolio
+
+Run:
+  cd e2e
+  pytest test_portfolio_user_requester.py -v
+  pytest test_portfolio_user_requester.py -v --headed
+  pytest test_portfolio_user_requester.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import (
+    BASE_URL,
+    assert_extended_header,
+    assert_portfolio_footer,
+    hide_debug_toolbar,
+    wait_for_table_rows,
+    continue_wizard_step,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestPortfolioUserRequester:
+    """Regression tests for the portfolio user with requester permissions (User 3)."""
+
+    @staticmethod
+    def _login(page, next_path="/"):
+        dev_auto_login(page, "portfolio_user_requester_3", next_path)
+
+    @staticmethod
+    def _fill_domain_request_form(page, requested_domain="requestertestdomain"):
+        """Fill the portfolio domain request wizard.
+
+        Portfolio wizard steps differ from the legacy wizard:
+          portfolio_requesting_entity → dotgov_domain → purpose →
+          portfolio_additional_details → requirements → review
+
+        Caller must already be on /request/start/. Django wizard prefixes all
+        field names as <step_name>-<field_name>.
+        """
+        page.locator("button[name='submit_button'][value='intro_acknowledge']").click()
+        page.wait_for_load_state("networkidle")
+
+        page.locator(
+            "input[name='portfolio_requesting_entity-requesting_entity_is_suborganization'][value='False']"
+        ).dispatch_event("click")
+        continue_wizard_step(page)
+
+        page.locator("input[name='dotgov_domain-requested_domain']").fill(requested_domain)
+        continue_wizard_step(page)
+
+        page.locator("textarea[name='purpose-purpose']").fill(
+            "Portfolio requester E2E regression test domain request."
+        )
+        continue_wizard_step(page)
+
+        # Use evaluate() here because the hidden radio doesn't respond to dispatch_event reliably
+        # in some Chromium builds — evaluate triggers the click directly on the DOM node.
+        page.evaluate("""
+            const radio = document.querySelector(
+                "input[name='portfolio_additional_details-has_anything_else_text'][value='False']"
+            );
+            if (radio) { radio.click(); }
+        """)
+        continue_wizard_step(page)
+
+        policy_checkbox = page.locator("input[name='requirements-is_policy_acknowledged']")
+        if policy_checkbox.count() > 0:
+            policy_checkbox.dispatch_event("click")
+            continue_wizard_step(page)
+
+        submit_link = page.locator("a[href='#toggle-submit-domain-request']")
+        if submit_link.is_visible():
+            submit_link.click()
+            page.wait_for_selector("#domain-request-form-submit-button", state="visible", timeout=5000)
+            page.locator("#domain-request-form-submit-button").click()
+            page.wait_for_load_state("networkidle")
+
+    def test_basic_member_with_requester_permissions_home_page(self, video_page):
+        """Portfolio home shows both tabs and the Start a new domain request option."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/domains/")
+
+        assert page.url.startswith(f"{BASE_URL}/domains/") or page.locator("h1").first.is_visible(), (
+            "Expected portfolio home page."
+        )
+
+        nav = page.get_by_label("Primary navigation")
+        assert nav.get_by_role("link", name="Domains", exact=True).is_visible(), (
+            "Domains tab should be visible."
+        )
+        assert (
+            nav.get_by_role("button", name="Domain requests").is_visible()
+            or nav.get_by_role("link", name="Domain requests", exact=True).is_visible()
+        ), "Domain requests tab should be visible."
+
+        if nav.get_by_role("button", name="Domain requests").is_visible():
+            nav.get_by_role("button", name="Domain requests").click()
+            page.get_by_role("link", name="Domain requests").first.click()
+        else:
+            nav.get_by_role("link", name="Domain requests", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        assert page.url.startswith(f"{BASE_URL}/requests/") or page.locator("h1").first.is_visible(), (
+            "Should be able to access the domain requests tab."
+        )
+
+        assert (
+            page.locator("a", has_text="Start a new domain request").is_visible()
+            or page.locator("button", has_text="Start a new domain request").is_visible()
+        ), "Start a new domain request should be visible for users with requester permissions."
+
+        assert_extended_header(page)
+        assert_portfolio_footer(page)
+
+    def test_portfolio_user_can_create_domain_request(self, video_page):
+        """User 3 can fill the portfolio domain request wizard and submit successfully."""
+        page = video_page
+        hide_debug_toolbar(page)
+        self._login(page, next_path="/requests/")
+
+        page.goto(f"{BASE_URL}/request/start/")
+        page.wait_for_load_state("networkidle")
+
+        assert page.locator("form").is_visible(), (
+            "Domain request creation form should load."
+        )
+        assert_extended_header(page)
+
+        requested_domain = "requestertestdomain"
+        self._fill_domain_request_form(page, requested_domain)
+
+        assert (
+            page.locator("h1", has_text="Thanks for your domain request!").is_visible()
+            or page.locator("text=Thanks for your domain request").is_visible()
+        ), "Form submission should show the confirmation page."
+
+        page.goto(f"{BASE_URL}/requests/")
+        page.wait_for_load_state("networkidle")
+
+        wait_for_table_rows(page, "domain-requests__table-wrapper")
+        requests_table = page.locator("#domain-requests__table-wrapper tbody")
+        assert requests_table.locator("td", has_text=requested_domain).first.is_visible(), (
+            f"New request '{requested_domain}' should appear in the table."
+        )

--- a/e2e/test_profile_page.py
+++ b/e2e/test_profile_page.py
@@ -1,0 +1,106 @@
+"""E2E regression tests: User Profile Page.
+
+Scenario: A user can log in (via dev auto-login bypass) and see / edit their profile page.
+
+Run:
+  cd e2e
+  pip install -r requirements.txt
+  playwright install chromium
+  pytest test_profile_page.py -v
+  pytest test_profile_page.py -v --headed
+  pytest test_profile_page.py -v --headed --slowmo 800
+"""
+
+import logging
+import pytest
+from utils import BASE_URL
+
+logger = logging.getLogger(__name__)
+
+AUTO_LOGIN_URL = f"{BASE_URL}/dev-auto-login/"
+
+# Axe-core impact levels that are hard failures; moderate/minor are logged only.
+_BLOCKING_IMPACT_LEVELS = {"critical", "serious"}
+
+
+class TestProfilePage:
+    """Regression tests for the user profile page (/user-profile).
+
+    All tests authenticate via the dev-only auto-login bypass, which creates
+    (or reuses) a local test user and logs them in through Django's session
+    auth — bypassing login.gov while using the real session machinery.
+    """
+
+    @staticmethod
+    def _login_and_go_to_profile(page):
+        page.goto(f"{AUTO_LOGIN_URL}?next=/user-profile")
+        page.wait_for_load_state("networkidle")
+
+    def test_user_can_see_profile_page(self, video_page):
+        """After auto-login the user lands on /user-profile with the expected heading and form fields."""
+        page = video_page
+        self._login_and_go_to_profile(page)
+
+        assert "/user-profile" in page.url, (
+            f"Expected /user-profile but got: {page.url}\n"
+            "Check that the app is running and ALLOW_AUTO_LOGIN=True is set."
+        )
+        assert page.locator("h1", has_text="Your profile").is_visible()
+        assert "Edit your User Profile" in page.title()
+        assert page.locator("h2", has_text="Contact information").is_visible()
+        assert page.locator("input#id_first_name").is_visible()
+        assert page.locator("input#id_last_name").is_visible()
+        assert page.locator("input#id_email").is_visible()
+
+    def test_profile_page_not_redirect_to_login(self, video_page):
+        """After auto-login the browser must not be redirected to the login.gov OIDC flow."""
+        page = video_page
+        self._login_and_go_to_profile(page)
+
+        assert "openid" not in page.url, f"Unexpected OIDC redirect: {page.url}"
+        assert "identitysandbox" not in page.url, f"Unexpected sandbox redirect: {page.url}"
+        assert "login.gov" not in page.url, f"Unexpected login.gov redirect: {page.url}"
+
+    def test_profile_page_accessibility(self, video_page, axe):
+        """Runs axe-core against the profile page; hard-fails on critical/serious violations."""
+        page = video_page
+        self._login_and_go_to_profile(page)
+
+        # Scope to #main-content to avoid pre-existing violations in shared footer/toolbar.
+        results = axe.run(page, context="#main-content")
+
+        all_violations = results.response["violations"]
+        blocking = [v for v in all_violations if v.get("impact") in _BLOCKING_IMPACT_LEVELS]
+        non_blocking = [v for v in all_violations if v.get("impact") not in _BLOCKING_IMPACT_LEVELS]
+
+        if non_blocking:
+            logger.warning("%d non-blocking accessibility issue(s) found:", len(non_blocking))
+            for v in non_blocking:
+                logger.warning("  [%s] %s: %s", v.get("impact"), v.get("id"), v.get("description"))
+                for node in v.get("nodes", [])[:2]:
+                    logger.warning("    Target: %s", node.get("target"))
+
+        if blocking:
+            pytest.fail(
+                f"{len(blocking)} blocking (critical/serious) accessibility violation(s) found:\n\n"
+                + results.generate_report()
+            )
+
+    def test_profile_form_can_be_filled_and_saved(self, video_page):
+        """Filling and saving the profile form shows the success banner."""
+        page = video_page
+        self._login_and_go_to_profile(page)
+
+        page.locator("input#id_first_name").fill("Regression")
+        page.locator("input#id_last_name").fill("Tester")
+        page.locator("input#id_title").fill("QA Engineer")
+        page.locator("input#id_phone").fill("+12025550199")
+
+        page.locator("button[type='submit']", has_text="Save").click()
+        page.wait_for_load_state("networkidle")
+
+        success_banner = page.locator(".usa-alert--success .usa-alert__body")
+        assert success_banner.is_visible(), (
+            "Expected a success alert after saving the profile."
+        )
+        assert "Your profile has been updated." in success_banner.inner_text()

--- a/e2e/test_session_management.py
+++ b/e2e/test_session_management.py
@@ -1,0 +1,114 @@
+"""E2E regression tests: Session Portfolio Management.
+
+Run:
+  cd e2e
+  pytest test_session_management.py -v
+  pytest test_session_management.py -v --headed
+  pytest test_session_management.py -v --headed --slowmo 600
+"""
+
+import logging
+import pytest
+from conftest import dev_auto_login
+from utils import BASE_URL, assert_extended_header, hide_debug_toolbar, select_portfolio
+
+logger = logging.getLogger(__name__)
+
+
+class TestSessionManagement:
+    """Regression tests for session portfolio management."""
+
+    @staticmethod
+    def _login_requester(page, next_path="/domains/"):
+        dev_auto_login(page, "portfolio_user_requester_3", next_path)
+
+    @staticmethod
+    def _login_multi_portfolio(page, next_path="/"):
+        dev_auto_login(page, "multi_portfolio_admin_7", next_path)
+
+    def test_session_portfolio_persistence(self, video_page):
+        """Portfolio context (org name) persists across Domains, Requests, and Profile pages."""
+        page = video_page
+        self._login_requester(page, next_path="/domains/")
+        hide_debug_toolbar(page)
+
+        nav = page.get_by_label("Primary navigation")
+        first_org = page.locator(".organization-nav-link").first.text_content().strip()
+        assert first_org != "", "Organization name should be present on login."
+
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").first.text_content().strip() == first_org, (
+            "Org name should persist on the Domains page."
+        )
+        assert not page.locator("text=Select a portfolio").is_visible(), (
+            "No unexpected redirect to the portfolio selector."
+        )
+
+        btn = nav.get_by_role("button", name="Domain requests")
+        if btn.is_visible():
+            btn.click()
+            page.locator("#basic-nav-section-two a").first.click()
+        else:
+            nav.get_by_role("link", name="Domain requests", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").first.text_content().strip() == first_org, (
+            "Org name should persist on the Domain requests page."
+        )
+
+        page.locator("button#user-profile-menu").first.click()
+        page.locator("#user-profile-submenu a", has_text="Your profile").click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert_extended_header(page)
+        assert page.locator(".organization-nav-link").first.text_content().strip() == first_org, (
+            "Org name should persist on the Profile page."
+        )
+
+    def test_portfolio_selection_session_update(self, video_page):
+        """Switching from Portfolio A to Portfolio B updates the session and all subsequent pages."""
+        page = video_page
+        self._login_multi_portfolio(page, next_path="/")
+        hide_debug_toolbar(page)
+
+        select_portfolio(page, index=0)
+        org_name_a = page.locator(".organization-nav-link").first.text_content().strip()
+        assert org_name_a != "", "Org name A should be visible."
+
+        nav = page.get_by_label("Primary navigation")
+        nav.get_by_role("link", name="Domains", exact=True).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+        assert page.locator(".organization-nav-link").first.text_content().strip() == org_name_a, (
+            "Session should maintain Portfolio A context."
+        )
+
+        orgs_button = page.locator("button#organizations-menu").first
+        orgs_button.click()
+        page.wait_for_selector("#organizations-submenu", state="visible", timeout=5_000)
+        hide_debug_toolbar(page)
+
+        page.locator("#organizations-submenu button.organization-button").nth(1).click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        org_name_b = page.locator(".organization-nav-link").first.text_content().strip()
+        assert org_name_b != org_name_a, (
+            f"Session should update to Portfolio B. Got '{org_name_b}' vs '{org_name_a}'"
+        )
+
+        nav.get_by_role("button", name="Domain requests").click()
+        page.locator("#basic-nav-section-two a").first.click()
+        page.wait_for_load_state("networkidle")
+        hide_debug_toolbar(page)
+
+        assert page.locator(".organization-nav-link").first.text_content().strip() == org_name_b, (
+            "Domain requests page should use Portfolio B context."
+        )
+        assert page.locator(".organization-nav-link").first.text_content().strip() != org_name_a, (
+            "No stale Portfolio A data should display."
+        )

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,0 +1,93 @@
+"""Shared helper utilities for E2E regression tests."""
+
+import os
+
+BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:8080")
+
+
+def hide_debug_toolbar(page):
+    """Hide the Django Debug Toolbar overlay so it doesn't intercept pointer events."""
+    try:
+        page.evaluate("""
+            const bar = document.getElementById('djDebug');
+            if (bar) { bar.style.display = 'none'; }
+            const handle = document.getElementById('djdt-hide-button');
+            if (handle) { handle.style.display = 'none'; }
+        """)
+    except Exception:
+        pass
+
+
+def wait_for_table_rows(page, table_id: str, timeout: int = 15_000):
+    """Wait for at least one data row in a JS-populated table."""
+    page.wait_for_selector(f"#{table_id} tbody tr", timeout=timeout)
+
+
+def assert_basic_header(page):
+    """Assert the single-navbar (legacy) header is present and the extended header is not."""
+    assert page.locator("header.usa-header--basic").is_visible(), (
+        "Expected basic header (usa-header--basic) for legacy users."
+    )
+    assert not page.locator("header.usa-header--extended").is_visible(), (
+        "Extended header should NOT be visible for legacy users."
+    )
+
+
+def assert_extended_header(page):
+    """Assert the dual-navbar (portfolio) header is present and the basic header is not."""
+    assert page.locator("header.usa-header--extended").is_visible(), (
+        "Expected extended header (usa-header--extended) for portfolio users."
+    )
+    assert not page.locator("header.usa-header--basic").is_visible(), (
+        "Basic header should NOT be visible for portfolio users."
+    )
+
+
+def assert_basic_footer(page):
+    """Assert legacy footer contains only Home and Your profile, with no portfolio links."""
+    footer = page.locator(".usa-footer__address")
+    assert footer.locator("a", has_text="Home").is_visible(), (
+        "Footer must contain a 'Home' link for legacy users."
+    )
+    assert footer.locator("a", has_text="Your profile").is_visible(), (
+        "Footer must contain a 'Your profile' link for legacy users."
+    )
+    assert not footer.locator("a", has_text="Domains").is_visible(), (
+        "Footer must NOT contain a 'Domains' link for legacy users."
+    )
+    assert not footer.locator("a", has_text="Domain requests").is_visible(), (
+        "Footer must NOT contain a 'Domain requests' link for legacy users."
+    )
+    assert not footer.locator("a", has_text="Organization").is_visible(), (
+        "Footer must NOT contain an 'Organization' link for legacy users."
+    )
+
+
+def assert_portfolio_footer(page):
+    """Assert portfolio footer contains Domains, Domain requests, Organization, and Your profile."""
+    footer = page.locator(".usa-footer__address")
+    assert footer.locator("a", has_text="Domains").is_visible(), (
+        "Footer must contain a 'Domains' link for portfolio users."
+    )
+    assert footer.locator("a", has_text="Domain requests").is_visible(), (
+        "Footer must contain a 'Domain requests' link for portfolio users."
+    )
+    assert footer.locator("a", has_text="Organization").is_visible(), (
+        "Footer must contain an 'Organization' link for portfolio users."
+    )
+    assert footer.locator("a", has_text="Your profile").is_visible(), (
+        "Footer must contain a 'Your profile' link for portfolio users."
+    )
+
+
+def select_portfolio(page, index: int = 0):
+    """Select the nth portfolio card on the /your-organizations/ page."""
+    page.locator("button.usa-card__container").nth(index).click()
+    page.wait_for_load_state("networkidle")
+    hide_debug_toolbar(page)
+
+
+def continue_wizard_step(page):
+    """Submit the current domain request wizard step and wait for the next page."""
+    page.locator("button[name='submit_button'][value='next']").click()
+    page.wait_for_load_state("networkidle")

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -25,12 +25,15 @@ services:
       - DJANGO_SECRET_KEY=really-long-random-string-BNPecI7+s8jMahQcGHZ3XQ5yUfRrSibdapVLIz0UemdktVPofDKcoy
       # Run Django in debug mode on local
       - DJANGO_DEBUG=True
+      # Enable dev-only auto-login bypass for local E2E regression tests
+      - ALLOW_AUTO_LOGIN=True
       # Set DJANGO_LOG_LEVEL in env
       - DJANGO_LOG_LEVEL=DEBUG
       # Run Django without production flags
       - IS_PRODUCTION=False
       # Tell Django where it is being hosted
-      - DJANGO_BASE_URL=http://localhost:8080
+      # TODO change back to 8080 if not running another instance
+      - DJANGO_BASE_URL=http://localhost:8081
       # Is this a production environment
       - IS_PRODUCTION
       # Public site URL link
@@ -68,8 +71,8 @@ services:
     stdin_open: true
     tty: true
     ports:
-      - "8080:8080"
-      - "5678:5678"  # debugger port
+      - "8081:8080" # TODO: change back changed from 8080:8080 because I have another instance of the app running
+      - "5679:5678"  # debugger port, change from 5678:5678
     # command: "python"
     command: >
       bash -c " python manage.py migrate &&
@@ -91,7 +94,8 @@ services:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=feedabee
     ports:
-      - "5432:5432"
+    # Todo: change back. changed this port from 5432 because I have another instance of the app running
+      - "5433:5432"
 
   node:
     platform: linux/amd64

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -32,8 +32,7 @@ services:
       # Run Django without production flags
       - IS_PRODUCTION=False
       # Tell Django where it is being hosted
-      # TODO change back to 8080 if not running another instance
-      - DJANGO_BASE_URL=http://localhost:8081
+      - DJANGO_BASE_URL=http://localhost:8080
       # Is this a production environment
       - IS_PRODUCTION
       # Public site URL link
@@ -71,8 +70,8 @@ services:
     stdin_open: true
     tty: true
     ports:
-      - "8081:8080" # TODO: change back changed from 8080:8080 because I have another instance of the app running
-      - "5679:5678"  # debugger port, change from 5678:5678
+      - "8080:8080"
+      - "5678:5678"
     # command: "python"
     command: >
       bash -c " python manage.py migrate &&
@@ -94,8 +93,7 @@ services:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=feedabee
     ports:
-    # Todo: change back. changed this port from 5432 because I have another instance of the app running
-      - "5433:5432"
+      - "5432:5432"
 
   node:
     platform: linux/amd64

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -115,11 +115,12 @@ BASE_DIR = path.resolve().parent.parent.parent
 # to function for the IS_PRODUCTION flag.
 DEBUG = env_debug
 
-# Only active when DEBUG=True; gates the /dev-auto-login/ bypass URL for E2E tests.
-ALLOW_AUTO_LOGIN = env_allow_auto_login and env_debug
-
 # Controls production specific feature toggles
 IS_PRODUCTION = env_is_production
+
+# Only active when DEBUG=True; gates the /dev-auto-login/ bypass URL for E2E tests.
+ALLOW_AUTO_LOGIN = env_allow_auto_login and not IS_PRODUCTION
+
 SECRET_ENCRYPT_METADATA = secret_encrypt_metadata
 BASE_URL = env_base_url
 
@@ -1018,6 +1019,7 @@ if DEBUG and not RUNNING_TESTS:
     # allow dev laptop and docker-compose network to connect
     ALLOWED_HOSTS += ("localhost", "app")
     SECURE_SSL_REDIRECT = False
+
     SECURE_HSTS_PRELOAD = False
 
     # discover potentially inefficient database queries

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -71,6 +71,9 @@ env_log_format = env.str("DJANGO_LOG_FORMAT", "console")
 env_base_url: str = env.str("DJANGO_BASE_URL")
 env_getgov_public_site_url = env.str("GETGOV_PUBLIC_SITE_URL", "")
 env_oidc_active_provider = env.str("OIDC_ACTIVE_PROVIDER", "identity sandbox")
+# Dev-only: when True, exposes /dev-auto-login/ to bypass login.gov for local E2E tests.
+# Must also have DEBUG=True. Never set this in sandbox or production environments.
+env_allow_auto_login = env.bool("ALLOW_AUTO_LOGIN", default=False)
 
 secret_login_key = b64decode(secret("DJANGO_SECRET_LOGIN_KEY", ""))
 secret_key = secret("DJANGO_SECRET_KEY")
@@ -111,6 +114,9 @@ BASE_DIR = path.resolve().parent.parent.parent
 # TODO - Investigate the behaviour of this flag. Does not appear
 # to function for the IS_PRODUCTION flag.
 DEBUG = env_debug
+
+# Only active when DEBUG=True; gates the /dev-auto-login/ bypass URL for E2E tests.
+ALLOW_AUTO_LOGIN = env_allow_auto_login and env_debug
 
 # Controls production specific feature toggles
 IS_PRODUCTION = env_is_production
@@ -740,6 +746,8 @@ LOGIN_URL = "/openid/login"
 # the initial login requests without erroring.
 LOGIN_REQUIRED_IGNORE_PATHS = [
     r"/openid/(.+)$",
+    # Dev-only auto-login bypass — must be reachable before a session exists
+    r"/dev-auto-login/$",
 ]
 
 # where to go after logging out

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -428,3 +428,10 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS and not setting
     urlpatterns += [
         path("__debug__/", include(debug_toolbar.urls)),
     ]
+
+# Dev-only: expose an auto-login URL for local E2E regression tests.
+# Bypasses login.gov — only active when ALLOW_AUTO_LOGIN=True and DEBUG=True.
+if settings.DEBUG  and getattr(settings, "ALLOW_AUTO_LOGIN", False):
+    urlpatterns += [
+        path("dev-auto-login/", views.dev_auto_login, name="dev-auto-login"),
+    ]

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -431,7 +431,7 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS and not setting
 
 # Dev-only: expose an auto-login URL for local E2E regression tests.
 # Bypasses login.gov — only active when ALLOW_AUTO_LOGIN=True and DEBUG=True.
-if settings.DEBUG  and getattr(settings, "ALLOW_AUTO_LOGIN", False):
+if settings.DEBUG and getattr(settings, "ALLOW_AUTO_LOGIN", False):
     urlpatterns += [
         path("dev-auto-login/", views.dev_auto_login, name="dev-auto-login"),
     ]

--- a/src/registrar/views/__init__.py
+++ b/src/registrar/views/__init__.py
@@ -26,7 +26,8 @@ from .portfolios import *
 from .transfer_user import TransferUserView
 from .member_domains_json import PortfolioMemberDomainsJson
 from .portfolio_members_json import PortfolioMembersJson
-# TODO - this is on dev only, 
+
+# TODO - this is on dev only,
 # option 1: change it so this view is only added  if settings indicates local dev
 # option 2: keep as is, but update to be a class (function was lazy)
-from .dev_auto_login import dev_auto_login 
+from .dev_auto_login import dev_auto_login

--- a/src/registrar/views/__init__.py
+++ b/src/registrar/views/__init__.py
@@ -26,3 +26,7 @@ from .portfolios import *
 from .transfer_user import TransferUserView
 from .member_domains_json import PortfolioMemberDomainsJson
 from .portfolio_members_json import PortfolioMembersJson
+# TODO - this is on dev only, 
+# option 1: change it so this view is only added  if settings indicates local dev
+# option 2: keep as is, but update to be a class (function was lazy)
+from .dev_auto_login import dev_auto_login 

--- a/src/registrar/views/dev_auto_login.py
+++ b/src/registrar/views/dev_auto_login.py
@@ -36,7 +36,6 @@ _AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
 # returns None if in non local env
 
 
-
 def _get_or_create_user(username, email, first_name, last_name, title, phone, **extra_fields):
     """Get or create an E2E test user, setting an unusable password on first creation."""
     user, created = User.objects.get_or_create(

--- a/src/registrar/views/dev_auto_login.py
+++ b/src/registrar/views/dev_auto_login.py
@@ -1,7 +1,7 @@
 """
 Dev-only view for bypassing login.gov during local E2E regression tests.
 
-This view is ONLY active when both DEBUG=True and ALLOW_AUTO_LOGIN=True are set
+This view is ONLY active when both IS_PRODUCTION=False and ALLOW_AUTO_LOGIN=True are set
 in the environment. It is never reachable in sandbox or production environments.
 """
 
@@ -9,37 +9,94 @@ import logging
 from django.conf import settings
 from django.contrib.auth import login
 from django.http import Http404, HttpResponseRedirect
-from registrar.models.user import User
+from django.utils.http import url_has_allowed_host_and_scheme
+from registrar.models import (
+    Contact,
+    Domain,
+    DomainInformation,
+    DomainRequest,
+    DraftDomain,
+    FederalAgency,
+    Portfolio,
+    User,
+    UserDomainRole,
+    UserGroup,
+    UserPortfolioPermission,
+    WaffleFlag,
+)
+from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
+from registrar.utility.constants import BranchChoices
 
 logger = logging.getLogger(__name__)
 
 _AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
 
-## Todo could make this a class and add more restrictions 
-# so it continuious checks that environment is correct and 
+# TODO: could make this a class and add more restrictions
+# so it continuously checks that environment is correct and
 # returns None if in non local env
-# definitely don't leave this as is
-def _create_generic_test_user(request):
-    """Generic E2E test user — no portfolio, no domains, just a working account.
-        Each key maps to a factory function: (request) -> User.
-        Factories use get_or_create throughout so they are idempotent.
-    """
+
+
+
+def _get_or_create_user(username, email, first_name, last_name, title, phone, **extra_fields):
+    """Get or create an E2E test user, setting an unusable password on first creation."""
     user, created = User.objects.get_or_create(
-        username="testuser-e2e",
+        username=username,
         defaults={
-            "email": "testuser-e2e@example.com",
-            "first_name": "E2E",
-            "last_name": "TestUser",
-            "title": "Test Engineer",
-            "phone": "+12025550100",
+            "email": email,
+            "first_name": first_name,
+            "last_name": last_name,
+            "title": title,
+            "phone": phone,
             "is_active": True,
+            **extra_fields,
         },
     )
     if created:
         user.set_unusable_password()
         user.save(update_fields=["password"])
-        logger.info("Created generic E2E test user")
+        logger.debug("Created E2E test user: %s", user.email)
     return user
+
+
+def _get_or_create_portfolio(user, name, roles, additional_permissions=None):
+    """Get or create a portfolio and assign the user to it with the given roles."""
+    portfolio, _ = Portfolio.objects.get_or_create(
+        organization_name=name,
+        defaults={"requester": user},
+    )
+    permission_defaults = {"roles": roles}
+    if additional_permissions:
+        permission_defaults["additional_permissions"] = additional_permissions
+    UserPortfolioPermission.objects.get_or_create(
+        user=user,
+        portfolio=portfolio,
+        defaults=permission_defaults,
+    )
+    return portfolio
+
+
+def _get_or_create_managed_domain(user, name):
+    """Get or create a READY domain and assign the user as its manager."""
+    domain, _ = Domain.objects.get_or_create(
+        name=name,
+        defaults={"state": Domain.State.READY},
+    )
+    UserDomainRole.objects.get_or_create(
+        user=user,
+        domain=domain,
+        defaults={"role": UserDomainRole.Roles.MANAGER},
+    )
+    return domain
+
+
+def _create_generic_test_user(request):
+    """Generic E2E test user — no portfolio, no domains, just a working account.
+    Each key maps to a factory function: (request) -> User.
+    Factories use get_or_create throughout so they are idempotent.
+    """
+    return _get_or_create_user(
+        "testuser-e2e", "testuser-e2e@example.com", "E2E", "TestUser", "Test Engineer", "+12025550100"
+    )
 
 
 def _create_legacy_user_1(request):
@@ -52,31 +109,14 @@ def _create_legacy_user_1(request):
       - UserDomainRole(MANAGER) for each domain
       - 1 submitted DomainRequest for sprinkledonut.gov
     """
-    # Import here to avoid module-level circular imports
-    from registrar.models import (
-        Domain,
-        DomainInformation,
-        DomainRequest,
-        UserDomainRole,
+    user = _get_or_create_user(
+        "regressiontest+1",
+        "regressiontest+1@gmail.com",
+        "Regression",
+        "One",
+        "Legacy Domain Manager",
+        "+12025550101",
     )
-    from registrar.models.contact import Contact
-    from registrar.models.draft_domain import DraftDomain
-
-    user, created = User.objects.get_or_create(
-        username="regressiontest+1",
-        defaults={
-            "email": "regressiontest+1@gmail.com",
-            "first_name": "Regression",
-            "last_name": "One",
-            "title": "Legacy Domain Manager",
-            "phone": "+12025550101",
-            "is_active": True,
-        },
-    )
-    if created:
-        user.set_unusable_password()
-        user.save(update_fields=["password"])
-        logger.info("Created legacy test user 1: %s", user.email)
 
     # Senior official contact (shared across all domains for simplicity)
     senior_official, _ = Contact.objects.get_or_create(
@@ -129,13 +169,460 @@ def _create_legacy_user_1(request):
     return user
 
 
+def _create_portfolio_user_2(request):
+    """
+    User 2 — basic member - domain manager.
+
+    Setup:
+      - 1 portfolio
+      - User has organization_member role in the portfolio
+      - At least 1 domain in the portfolio
+    """
+    user = _get_or_create_user(
+        "regressiontest+2",
+        "regressiontest+2@gmail.com",
+        "Regression",
+        "Two",
+        "Basic Domain Manager",
+        "+12025550103",
+    )
+
+    portfolio = _get_or_create_portfolio(
+        user,
+        "Test Portfolio 2",
+        [UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+    )
+
+    # Add a domain to the portfolio and assign user as manager
+    domain, _ = Domain.objects.get_or_create(
+        name="testdomain2.gov",
+        defaults={"state": Domain.State.READY},
+    )
+
+    # DomainInformation.portfolio is the field the portfolio domains view queries
+    DomainInformation.objects.update_or_create(
+        domain=domain,
+        defaults={"requester": user, "portfolio": portfolio},
+    )
+
+    UserDomainRole.objects.get_or_create(
+        user=user,
+        domain=domain,
+        defaults={"role": UserDomainRole.Roles.MANAGER},
+    )
+
+    return user
+
+
+def _create_portfolio_user_requester_3(request):
+    """
+    User 3 — basic member - domain manager and requester.
+
+    Setup:
+      - 1 portfolio
+      - User has organization_member role with EDIT_REQUESTS additional permission
+      - At least 1 domain in the portfolio
+    """
+    user = _get_or_create_user(
+        "regressiontest+3",
+        "regressiontest+3@gmail.com",
+        "Regression",
+        "Three",
+        "Domain Manager Requester",
+        "+12025550104",
+    )
+
+    portfolio = _get_or_create_portfolio(
+        user,
+        "Test Portfolio 3",
+        [UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+        additional_permissions=[UserPortfolioPermissionChoices.EDIT_REQUESTS],
+    )
+
+    # Add a domain to the portfolio and assign user as manager
+    domain, _ = Domain.objects.get_or_create(
+        name="testdomain3.gov",
+        defaults={"state": Domain.State.READY},
+    )
+
+    DomainInformation.objects.update_or_create(
+        domain=domain,
+        defaults={"requester": user, "portfolio": portfolio},
+    )
+
+    UserDomainRole.objects.get_or_create(
+        user=user,
+        domain=domain,
+        defaults={"role": UserDomainRole.Roles.MANAGER},
+    )
+
+    return user
+
+
+def _create_org_admin_4(request):
+    """
+    User 4 — organization admin.
+
+    Setup:
+      - 1 portfolio
+      - User has organization admin permission
+      - Portfolio has domains and domain requests
+    """
+    user = _get_or_create_user(
+        "regressiontest+4",
+        "regressiontest+4@gmail.com",
+        "Regression",
+        "Four",
+        "Org Admin",
+        "+12025550105",
+    )
+
+    portfolio = _get_or_create_portfolio(
+        user,
+        "Test Portfolio 4",
+        [UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+    )
+
+    # Add domains and requests
+    domain, _ = Domain.objects.get_or_create(
+        name="testdomain4.gov",
+        defaults={"state": Domain.State.READY},
+    )
+
+    DomainInformation.objects.update_or_create(
+        domain=domain,
+        defaults={"requester": user, "portfolio": portfolio},
+    )
+
+    draft, _ = DraftDomain.objects.get_or_create(name="testrequest4.gov")
+    DomainRequest.objects.update_or_create(
+        requester=user,
+        requested_domain=draft,
+        defaults={"status": DomainRequest.DomainRequestStatus.SUBMITTED, "portfolio": portfolio},
+    )
+
+    return user
+
+
+def _create_mixed_permissions_6(request):
+    """
+    User 6 — org admin in 1 portfolio + legacy domain manager.
+
+    Setup:
+      - 1 portfolio with org admin permission
+      - Legacy domains managed by user
+    """
+    user = _get_or_create_user(
+        "regressiontest+6",
+        "regressiontest+6@gmail.com",
+        "Regression",
+        "Six",
+        "Mixed Permissions",
+        "+12025550107",
+    )
+
+    portfolio = _get_or_create_portfolio(
+        user,
+        "Test Portfolio 6",
+        [UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+    )
+
+    # Portfolio domain (visible in portfolio domains table)
+    portfolio_domain, _ = Domain.objects.get_or_create(
+        name="testdomain6.gov",
+        defaults={"state": Domain.State.READY},
+    )
+
+    DomainInformation.objects.update_or_create(
+        domain=portfolio_domain,
+        defaults={"requester": user, "portfolio": portfolio},
+    )
+
+    UserDomainRole.objects.get_or_create(
+        user=user,
+        domain=portfolio_domain,
+        defaults={"role": UserDomainRole.Roles.MANAGER},
+    )
+
+    # Legacy domain (no portfolio — appears only outside portfolio context)
+    legacy_domain, _ = Domain.objects.get_or_create(
+        name="legacy6.gov",
+        defaults={"state": Domain.State.READY},
+    )
+
+    UserDomainRole.objects.get_or_create(
+        user=user,
+        domain=legacy_domain,
+        defaults={"role": UserDomainRole.Roles.MANAGER},
+    )
+
+    senior_official, _ = Contact.objects.get_or_create(
+        email="senior6@example.com",
+        defaults={
+            "first_name": "Senior6",
+            "last_name": "Official",
+            "title": "Director",
+            "phone": "+12025550108",
+        },
+    )
+
+    DomainInformation.objects.get_or_create(
+        domain=legacy_domain,
+        defaults={
+            "requester": user,
+            "senior_official": senior_official,
+        },
+    )
+
+    return user
+
+
+def _create_multi_portfolio_admin_7(request):
+    """
+    User 7 — organization admin in 2 different portfolios.
+
+    Setup:
+      - 2 portfolios
+      - User has org admin permission in both
+      - multiple_portfolios waffle flag enabled for everyone
+    """
+    user = _get_or_create_user(
+        "regressiontest+7",
+        "regressiontest+7@gmail.com",
+        "Regression",
+        "Seven",
+        "Multi Portfolio Admin",
+        "+12025550109",
+    )
+
+    # Enable the multiple_portfolios feature flag only for user 7
+    # Use per-user activation (not everyone=True) to avoid breaking other users
+    flag, _ = WaffleFlag.objects.update_or_create(
+        name="multiple_portfolios",
+        defaults={"everyone": None},  # Not globally enabled; use per-user control
+    )
+    flag.users.add(user)
+
+    _get_or_create_portfolio(user, "Test Portfolio 7A", [UserPortfolioRoleChoices.ORGANIZATION_ADMIN])
+    _get_or_create_portfolio(user, "Test Portfolio 7B", [UserPortfolioRoleChoices.ORGANIZATION_ADMIN])
+
+    return user
+
+
+def _seed_non_federal_requests(user, senior_official):
+    """Seed non-federal domain requests for the admin analyst user."""
+    Status = DomainRequest.DomainRequestStatus
+    Reasons = DomainRequest.RejectionReasons
+    non_federal = [
+        # (draft_name, org_type, status, is_election, rejection_reason)
+        ("a8city1.gov", "city", Status.SUBMITTED, False, None),
+        ("a8city2.gov", "city", Status.IN_REVIEW, False, None),
+        ("a8city3.gov", "city", Status.REJECTED, False, Reasons.DOMAIN_PURPOSE),
+        ("a8county1.gov", "county", Status.SUBMITTED, False, None),
+        ("a8county2.gov", "county", Status.IN_REVIEW, False, None),
+        ("a8state1.gov", "state_or_territory", Status.SUBMITTED, False, None),
+        ("a8state2.gov", "state_or_territory", Status.ACTION_NEEDED, False, None),
+        ("a8tribal1.gov", "tribal", Status.SUBMITTED, False, None),
+        ("a8school1.gov", "school_district", Status.SUBMITTED, False, None),
+        ("a8interstate1.gov", "interstate", Status.SUBMITTED, False, None),
+        ("a8specdistr1.gov", "special_district", Status.IN_REVIEW, False, None),
+        ("a8electcity1.gov", "city", Status.SUBMITTED, True, None),
+        ("a8electcounty1.gov", "county", Status.SUBMITTED, True, None),
+    ]
+    for name, org_type, status, is_election, rejection_reason in non_federal:
+        draft, _ = DraftDomain.objects.get_or_create(name=name)
+        defaults = {
+            "requester": user,
+            "status": status,
+            "generic_org_type": org_type,
+            "is_election_board": is_election,
+            "senior_official": senior_official,
+            "organization_name": f"Test Org {name}",
+            "city": "Washington",
+            "state_territory": "DC",
+            "address_line1": "123 Test St",
+            "zipcode": "20001",
+        }
+        if rejection_reason:
+            defaults["rejection_reason"] = rejection_reason
+        DomainRequest.objects.update_or_create(requested_domain=draft, defaults=defaults)
+
+
+def _seed_federal_requests(user, senior_official, exec_agency, judicial_agency, legislative_agency):
+    """Seed federal domain requests for the admin analyst user."""
+    Status = DomainRequest.DomainRequestStatus
+    Reasons = DomainRequest.RejectionReasons
+    federal = [
+        # (draft_name, agency, federal_type, status, rejection_reason)
+        ("a8fedexec1.gov", exec_agency, BranchChoices.EXECUTIVE, Status.SUBMITTED, None),
+        ("a8fedexec2.gov", exec_agency, BranchChoices.EXECUTIVE, Status.IN_REVIEW, None),
+        ("a8fedjud1.gov", judicial_agency, BranchChoices.JUDICIAL, Status.SUBMITTED, None),
+        ("a8fedleg1.gov", legislative_agency, BranchChoices.LEGISLATIVE, Status.IN_REVIEW, None),
+        ("a8fedexec3.gov", exec_agency, BranchChoices.EXECUTIVE, Status.ACTION_NEEDED, None),
+        ("a8fedjud2.gov", judicial_agency, BranchChoices.JUDICIAL, Status.REJECTED, Reasons.ORG_NOT_ELIGIBLE),
+    ]
+    for name, agency, fed_type, status, rejection_reason in federal:
+        draft, _ = DraftDomain.objects.get_or_create(name=name)
+        defaults = {
+            "requester": user,
+            "status": status,
+            "generic_org_type": DomainRequest.OrganizationChoices.FEDERAL,
+            "federal_type": fed_type,
+            "federal_agency": agency,
+            "senior_official": senior_official,
+            "organization_name": agency.agency,
+            "city": "Washington",
+            "state_territory": "DC",
+            "address_line1": "123 Federal Ave",
+            "zipcode": "20001",
+        }
+        if rejection_reason:
+            defaults["rejection_reason"] = rejection_reason
+        DomainRequest.objects.update_or_create(requested_domain=draft, defaults=defaults)
+
+
+def _create_django_admin_analyst_8(request):
+    """
+    User 8 — Django admin analyst: is_staff=True, is_superuser=True, cisa_analysts_group.
+
+    Setup:
+      - Staff + superuser permissions (can access Django admin)
+      - Member of cisa_analysts_group (analyst access permission)
+      - Rich test dataset: domain requests in many statuses + domains for filter testing
+        * Non-federal: city, county, state_or_territory, tribal, school_district, interstate, special_district
+        * Federal: executive, judicial, legislative branches
+        * Election board variants
+        * Rejected requests with rejection reasons
+        * Approved requests with corresponding Domain + DomainInformation objects
+
+    Workflow test target:
+      a8city1.gov — SUBMITTED, no pre-existing domain (test will set investigator + change status)
+    """
+    user = _get_or_create_user(
+        "regressiontest+8",
+        "regressiontest+8@example.com",
+        "Analyst",
+        "Eight",
+        "CISA Analyst",
+        "+12025550110",
+        is_staff=True,
+        is_superuser=True,
+    )
+    if not user.is_staff or not user.is_superuser:
+        user.is_staff = True
+        user.is_superuser = True
+        user.save(update_fields=["is_staff", "is_superuser"])
+
+    # Add to cisa_analysts_group (created by migrations)
+    analyst_group, _ = UserGroup.objects.get_or_create(name="cisa_analysts_group")
+    user.groups.add(analyst_group)
+
+    # Shared senior official
+    senior_official, _ = Contact.objects.get_or_create(
+        email="senior8@example.com",
+        defaults={
+            "first_name": "Senior8",
+            "last_name": "Official",
+            "title": "Director",
+            "phone": "+12025550200",
+        },
+    )
+
+    # Federal agencies
+    exec_agency, _ = FederalAgency.objects.get_or_create(
+        agency="Test Executive Agency E2E",
+        defaults={"federal_type": BranchChoices.EXECUTIVE},
+    )
+    judicial_agency, _ = FederalAgency.objects.get_or_create(
+        agency="Test Judicial Agency E2E",
+        defaults={"federal_type": BranchChoices.JUDICIAL},
+    )
+    legislative_agency, _ = FederalAgency.objects.get_or_create(
+        agency="Test Legislative Agency E2E",
+        defaults={"federal_type": BranchChoices.LEGISLATIVE},
+    )
+
+    _seed_non_federal_requests(user, senior_official)
+    _seed_federal_requests(user, senior_official, exec_agency, judicial_agency, legislative_agency)
+
+    # Approved requests — manually create Domain + DomainInformation
+    approved = [
+        # (domain_name, org_type, agency, fed_type, domain_state, is_election)
+        ("a8citya.gov", "city", None, None, Domain.State.READY, False),
+        ("a8countya.gov", "county", None, None, Domain.State.READY, False),
+        ("a8statea.gov", "state_or_territory", None, None, Domain.State.ON_HOLD, False),
+        ("a8fedexeca.gov", "federal", exec_agency, BranchChoices.EXECUTIVE, Domain.State.READY, False),
+        ("a8fedjuda.gov", "federal", judicial_agency, BranchChoices.JUDICIAL, Domain.State.READY, False),
+        ("a8electa.gov", "city", None, None, Domain.State.READY, True),
+    ]
+
+    for domain_name, org_type, agency, fed_type, domain_state, is_election in approved:
+        domain, _ = Domain.objects.get_or_create(
+            name=domain_name,
+            defaults={"state": domain_state},
+        )
+        di_defaults = {
+            "requester": user,
+            "generic_org_type": org_type,
+            "senior_official": senior_official,
+            "organization_name": f"Test Org {domain_name}",
+            "is_election_board": is_election,
+        }
+        if agency:
+            di_defaults["federal_agency"] = agency
+            di_defaults["federal_type"] = fed_type
+        DomainInformation.objects.update_or_create(domain=domain, defaults=di_defaults)
+
+        draft, _ = DraftDomain.objects.get_or_create(name=domain_name)
+        dr_defaults = {
+            "requester": user,
+            "status": DomainRequest.DomainRequestStatus.APPROVED,
+            "approved_domain": domain,
+            "generic_org_type": org_type,
+            "is_election_board": is_election,
+            "senior_official": senior_official,
+            "organization_name": f"Test Org {domain_name}",
+            "city": "Washington",
+            "state_territory": "DC",
+            "address_line1": "123 Test St",
+            "zipcode": "20001",
+        }
+        if agency:
+            dr_defaults["federal_agency"] = agency
+            dr_defaults["federal_type"] = fed_type
+        DomainRequest.objects.update_or_create(requested_domain=draft, defaults=dr_defaults)
+
+    # The workflow test changes a8city1.gov (sets investigator, then approves it).
+    # Reset it to a clean state on every login so the test is idempotent.
+    try:
+        workflow_draft = DraftDomain.objects.get(name="a8city1.gov")
+        # Clear approved_domain before deleting to avoid FK PROTECT violations.
+        DomainRequest.objects.filter(requested_domain=workflow_draft).update(
+            investigator=None,
+            status=DomainRequest.DomainRequestStatus.SUBMITTED,
+            approved_domain=None,
+        )
+        # Delete DomainInformation first (references Domain), then the Domain itself.
+        DomainInformation.objects.filter(domain__name="a8city1.gov").delete()
+        Domain.objects.filter(name="a8city1.gov").delete()
+    except DraftDomain.DoesNotExist:
+        pass
+
+    return user
+
+
 # Map persona query param values to factory functions
 # TODO- more reason to have this as a class, below can be the helper
 _PERSONAS = {
     "generic": _create_generic_test_user,
     "legacy_user_1": _create_legacy_user_1,
+    "portfolio_user_2": _create_portfolio_user_2,
+    "portfolio_user_requester_3": _create_portfolio_user_requester_3,
+    "org_admin_4": _create_org_admin_4,
+    "mixed_permissions_6": _create_mixed_permissions_6,
+    "multi_portfolio_admin_7": _create_multi_portfolio_admin_7,
+    "django_admin_analyst_8": _create_django_admin_analyst_8,
 }
-
 
 
 def dev_auto_login(request):
@@ -149,13 +636,18 @@ def dev_auto_login(request):
 
     Guards:
       - Returns 404 unless settings.ALLOW_AUTO_LOGIN is True.
-      - ALLOW_AUTO_LOGIN is forced False unless DEBUG=True (settings.py).
+      - Returns 404 unless settings.IS_PRODUCTION is False (settings.py).
+      - Gating by using both flags while providing a way to enable some sandboxes to use this view and not others
     """
     if not getattr(settings, "ALLOW_AUTO_LOGIN", False):
         raise Http404("Dev auto-login is not enabled.")
 
     persona_key = request.GET.get("persona", "generic")
     next_url = request.GET.get("next", "/user-profile")
+
+    #  If the next_url is not a safe URL just go to user profile
+    if not url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+        next_url = "/user-profile"
 
     factory = _PERSONAS.get(persona_key)
     if factory is None:

--- a/src/registrar/views/dev_auto_login.py
+++ b/src/registrar/views/dev_auto_login.py
@@ -1,0 +1,167 @@
+"""
+Dev-only view for bypassing login.gov during local E2E regression tests.
+
+This view is ONLY active when both DEBUG=True and ALLOW_AUTO_LOGIN=True are set
+in the environment. It is never reachable in sandbox or production environments.
+"""
+
+import logging
+from django.conf import settings
+from django.contrib.auth import login
+from django.http import Http404, HttpResponseRedirect
+from registrar.models.user import User
+
+logger = logging.getLogger(__name__)
+
+_AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
+
+## Todo could make this a class and add more restrictions 
+# so it continuious checks that environment is correct and 
+# returns None if in non local env
+# definitely don't leave this as is
+def _create_generic_test_user(request):
+    """Generic E2E test user — no portfolio, no domains, just a working account.
+        Each key maps to a factory function: (request) -> User.
+        Factories use get_or_create throughout so they are idempotent.
+    """
+    user, created = User.objects.get_or_create(
+        username="testuser-e2e",
+        defaults={
+            "email": "testuser-e2e@example.com",
+            "first_name": "E2E",
+            "last_name": "TestUser",
+            "title": "Test Engineer",
+            "phone": "+12025550100",
+            "is_active": True,
+        },
+    )
+    if created:
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+        logger.info("Created generic E2E test user")
+    return user
+
+
+def _create_legacy_user_1(request):
+    """
+    User 1 — legacy domain manager with no portfolio.
+
+    Setup:
+      - 3 domains in READY state (donutdefenders.gov, alienoutpost.gov, alicornalliance.gov)
+      - DomainInformation for each with a senior official Contact
+      - UserDomainRole(MANAGER) for each domain
+      - 1 submitted DomainRequest for sprinkledonut.gov
+    """
+    # Import here to avoid module-level circular imports
+    from registrar.models import (
+        Domain,
+        DomainInformation,
+        DomainRequest,
+        UserDomainRole,
+    )
+    from registrar.models.contact import Contact
+    from registrar.models.draft_domain import DraftDomain
+
+    user, created = User.objects.get_or_create(
+        username="regressiontest+1",
+        defaults={
+            "email": "regressiontest+1@gmail.com",
+            "first_name": "Regression",
+            "last_name": "One",
+            "title": "Legacy Domain Manager",
+            "phone": "+12025550101",
+            "is_active": True,
+        },
+    )
+    if created:
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+        logger.info("Created legacy test user 1: %s", user.email)
+
+    # Senior official contact (shared across all domains for simplicity)
+    senior_official, _ = Contact.objects.get_or_create(
+        email="senior.official+e2e@example.com",
+        defaults={
+            "first_name": "Senior",
+            "last_name": "Official",
+            "title": "Director",
+            "phone": "+12025550102",
+        },
+    )
+
+    domain_names = [
+        "donutdefenders.gov",
+        "alienoutpost.gov",
+        "alicornalliance.gov",
+    ]
+
+    for name in domain_names:
+        domain, _ = Domain.objects.get_or_create(
+            name=name,
+            defaults={"state": Domain.State.READY},
+        )
+
+        DomainInformation.objects.get_or_create(
+            domain=domain,
+            defaults={
+                "requester": user,
+                "senior_official": senior_official,
+            },
+        )
+
+        UserDomainRole.objects.get_or_create(
+            user=user,
+            domain=domain,
+            defaults={"role": UserDomainRole.Roles.MANAGER},
+        )
+
+    # Submitted domain request for sprinkledonut.gov
+    draft_domain, _ = DraftDomain.objects.get_or_create(
+        name="sprinkledonut.gov",
+    )
+    DomainRequest.objects.get_or_create(
+        requester=user,
+        requested_domain=draft_domain,
+        defaults={"status": DomainRequest.DomainRequestStatus.SUBMITTED},
+    )
+
+    logger.info("Legacy user 1 setup complete: %d domains, 1 domain request", len(domain_names))
+    return user
+
+
+# Map persona query param values to factory functions
+# TODO- more reason to have this as a class, below can be the helper
+_PERSONAS = {
+    "generic": _create_generic_test_user,
+    "legacy_user_1": _create_legacy_user_1,
+}
+
+
+
+def dev_auto_login(request):
+    """
+    Creates (or retrieves) a test user for the requested persona, logs them in,
+    then redirects to the URL specified by the `next` query param.
+
+    Query params:
+      persona  — which test user to create/use (default: "generic")
+      next     — where to redirect after login (default: "/user-profile")
+
+    Guards:
+      - Returns 404 unless settings.ALLOW_AUTO_LOGIN is True.
+      - ALLOW_AUTO_LOGIN is forced False unless DEBUG=True (settings.py).
+    """
+    if not getattr(settings, "ALLOW_AUTO_LOGIN", False):
+        raise Http404("Dev auto-login is not enabled.")
+
+    persona_key = request.GET.get("persona", "generic")
+    next_url = request.GET.get("next", "/user-profile")
+
+    factory = _PERSONAS.get(persona_key)
+    if factory is None:
+        raise Http404(f"Unknown persona: {persona_key!r}. Available: {list(_PERSONAS)}")
+
+    user = factory(request)
+    login(request, user, backend=_AUTH_BACKEND)
+    logger.info("Auto-logged in persona=%r as %s → %s", persona_key, user.username, next_url)
+    return HttpResponseRedirect(next_url)


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3583 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- regression testing designed for local running
- Copilot used to help autogenerate the test data 
- Not a complete regression test suite yet. Checks: domain request flow to submission on the user side, and through approval on the django admin side. Checks ability to view domain requests and domains, Doesn't check any commands that use EPP (like adding nameservers, putting it on hold, etc), this would require running it in a sandbox 
- checks with various permission configurations, hence multiple types of users for different tests.
- MORE changes should be added here but in interest of time leaving this as is

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->
-
## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
