### PR TITLE
#4688: Fix DNS record type state on Add record form

### DIFF
--- a/src/registrar/templates/domain_dns_records.html
+++ b/src/registrar/templates/domain_dns_records.html
@@ -14,8 +14,12 @@
 
 
 {% block domain_content %}
-<!-- Wrapped div to store showFormId to track across all the forms on the page, so only one form appears at a time-->
-<div x-data="{ showFormId: null, recordType: '', openComments: []}" @record-submit-success.camel.window="showFormId = null">
+<!-- Wrapped div to store showFormId to track across all the forms on the page, so only one form appears at a time.
+     x-effect clears recordType whenever the form closes, so reopening Add record always starts on the type dropdown. -->
+<div
+    x-data="{ showFormId: null, recordType: '', openComments: []}"
+    x-effect="showFormId === null ? recordType = '' : null"
+    @record-submit-success.camel.window="showFormId = null">
 
     {% include "includes/form_errors.html" with form=form %}
     <div id="dnsrecords-form-container">

--- a/src/registrar/templates/domain_dns_records.html
+++ b/src/registrar/templates/domain_dns_records.html
@@ -14,11 +14,12 @@
 
 
 {% block domain_content %}
-<!-- Wrapped div to store showFormId to track across all the forms on the page, so only one form appears at a time.
-     x-effect clears recordType whenever the form closes, so reopening Add record always starts on the type dropdown. -->
+<!-- showFormId tracks which form is open so only one shows at a time.
+     x-effect clears recordType when the form closes (null) or opens to Add (0),
+     so Add record always starts on a fresh type dropdown. -->
 <div
     x-data="{ showFormId: null, recordType: '', openComments: []}"
-    x-effect="showFormId === null ? recordType = '' : null"
+    x-effect="showFormId === null || showFormId === 0 ? recordType = '' : null"
     @record-submit-success.camel.window="showFormId = null">
 
     {% include "includes/form_errors.html" with form=form %}

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -97,27 +97,30 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
     @override_flag("dns_hosting", active=True)
     @less_console_noise_decorator
     def test_add_record_resets_record_type_alpine_state(self):
-        """Issue #4688: reopening 'Add record' after a submit showed the form body
-        already drawn, like a type had been picked. Closing the form sets showFormId
-        to null, and x-effect clears recordType whenever showFormId is null. This
-        test keeps that wiring in place.
+        """Issue #4688: Add record kept the last picked type drawn after a submit
+        or when switched to from an edit form with errors. The wrapper x-effect
+        clears recordType when showFormId is null or 0, and x-model on the type
+        select keeps the dropdown in sync. This test keeps that wiring in place.
         """
         response = self.client.get(self._url())
 
-        # The wrapper div ties recordType to showFormId so closing the form clears
-        # the type pick.
+        # x-effect clears recordType when the form closes (null) or Add opens (0).
         self.assertContains(
             response,
-            "x-effect=\"showFormId === null ? recordType = '' : null\"",
+            "x-effect=\"showFormId === null || showFormId === 0 ? recordType = '' : null\"",
         )
-        # Closing the form on submit-success drives recordType back to '' via the
-        # x-effect above.
+        # Add record sets showFormId to 0, which fires the x-effect.
+        self.assertContains(response, 'x-on:click="showFormId = 0"')
+        # Cancel sets showFormId to null, which also fires the x-effect.
+        self.assertContains(response, 'x-on:click="showFormId = null"')
+        # Submit success closes the form the same way.
         self.assertContains(
             response,
             '@record-submit-success.camel.window="showFormId = null"',
         )
-        # Cancel closes the form, which clears recordType via x-effect.
-        self.assertContains(response, 'x-on:click="showFormId = null"')
+        # x-model keeps the type dropdown in sync with recordType, so clearing
+        # recordType resets the dropdown to the empty option.
+        self.assertContains(response, 'x-model="recordType"')
 
     @override_flag("dns_hosting", active=True)
     @less_console_noise_decorator

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -96,6 +96,31 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
 
     @override_flag("dns_hosting", active=True)
     @less_console_noise_decorator
+    def test_add_record_resets_record_type_alpine_state(self):
+        """Issue #4688: reopening 'Add record' after a submit showed the form body
+        already drawn, like a type had been picked. Closing the form sets showFormId
+        to null, and x-effect clears recordType whenever showFormId is null. This
+        test keeps that wiring in place.
+        """
+        response = self.client.get(self._url())
+
+        # The wrapper div ties recordType to showFormId so closing the form clears
+        # the type pick.
+        self.assertContains(
+            response,
+            "x-effect=\"showFormId === null ? recordType = '' : null\"",
+        )
+        # Closing the form on submit-success drives recordType back to '' via the
+        # x-effect above.
+        self.assertContains(
+            response,
+            '@record-submit-success.camel.window="showFormId = null"',
+        )
+        # Cancel closes the form, which clears recordType via x-effect.
+        self.assertContains(response, 'x-on:click="showFormId = null"')
+
+    @override_flag("dns_hosting", active=True)
+    @less_console_noise_decorator
     def test_post_valid_forms_create_dns_records_success(self):
         for data in self.RECORD_TEST_CASES:
             with self.subTest(record_type=data["type"]):


### PR DESCRIPTION
## Ticket

Resolves #4688

## Changes

- Reset the `recordType` Alpine variable when the Add record form opens, when a record is successfully submitted, and when Cancel is clicked.
- Added a regression test that checks the click handlers stay wired up so this bug doesn't sneak back in.

## Context for reviewers

After adding a record, clicking "Add record" again was opening the form with all the body fields visible, like a type had already been picked. The dropdown itself was rendering empty (the HTML had the empty option selected), but the rest of the form was still showing.

The cause: `recordType` lives in the page-level Alpine `x-data` scope, so it stuck around between submissions. When htmx swapped in the fresh form HTML, the dropdown reset to empty but `recordType` kept its old value (e.g. `"A"`), so `x-show="recordType"` on the form body stayed true.

The fix is to clear `recordType` in the same spots we already clear `showFormId` — Add record click, submit-success, and Cancel — so the two pieces of state stay in sync.

Since the bug is Alpine state behavior, the test asserts the template-level click handlers are present (same pattern as the existing tab-order tests). It can't drive the JS, but it guards the hooks so a future template edit can't silently regress this.

## Setup
Note: You will need env vars setup for dns hosting. View cf instance glacier env vars and our Engineering Master doc.
1. Make sure the `dns_hosting` waffle flag is on and the domain used for testing is enrolled in dns hosting.
2. Go to a domain overview, then DNS > DNS records
3. Click "Add record" — the dropdown should be empty with no other fields showing
4. Pick a type, fill out the form, save it
5. Click "Add record" again — the dropdown should be empty again, no form body showing until you pick a type
6. Try the same thing but click Cancel instead of saving — reopening should still start clean

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [x] Checked different states (empty, one, some, error)
- [x] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
