### PR TITLE
#5046: Fix member export when DI is blank.

### DIFF
--- a/src/registrar/fixtures/fixtures_user_portfolio_permissions.py
+++ b/src/registrar/fixtures/fixtures_user_portfolio_permissions.py
@@ -4,7 +4,7 @@ from faker import Faker
 
 from registrar.fixtures.fixtures_portfolios import PortfolioFixture
 from registrar.fixtures.fixtures_users import UserFixture
-from registrar.models import User
+from registrar.models import PortfolioInvitation, User
 from registrar.models.portfolio import Portfolio
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
@@ -75,6 +75,7 @@ class UserPortfolioPermissionFixture:
         # Bulk create permissions
         cls._bulk_create_permissions(user_portfolio_permissions_to_create)
         cls.load_standard_user_permissions()
+        cls.load_empty_member_states()
 
     @classmethod
     def load_standard_user_permissions(cls):
@@ -122,6 +123,39 @@ class UserPortfolioPermissionFixture:
 
         # Bulk create permissions for standard users
         cls._bulk_create_permissions(permissions_to_create)
+
+    @classmethod
+    def load_empty_member_states(cls):
+        """Seed a portfolio member and invitation with no domain assignments."""
+        portfolio = Portfolio.objects.filter(organization_name__isnull=False).order_by("organization_name").first()
+        if not portfolio:
+            logger.warning("No seed portfolio found; skipping empty-state fixture.")
+            return
+
+        ghost, _ = User.objects.get_or_create(
+            username="ghost-member",
+            defaults={
+                "email": "ghost@example.com",
+                "first_name": "Ghost",
+                "last_name": "Member",
+            },
+        )
+        UserPortfolioPermission.objects.get_or_create(
+            user=ghost,
+            portfolio=portfolio,
+            defaults={"roles": [UserPortfolioRoleChoices.ORGANIZATION_MEMBER]},
+        )
+
+        PortfolioInvitation.objects.get_or_create(
+            email="no-domains@example.com",
+            portfolio=portfolio,
+            defaults={"roles": [UserPortfolioRoleChoices.ORGANIZATION_MEMBER]},
+        )
+
+        logger.info(
+            f"Loaded empty-domain-info member states on portfolio "
+            f"'{portfolio.organization_name}' (id={portfolio.id})."
+        )
 
     @classmethod
     def _bulk_create_permissions(cls, user_portfolio_permissions_to_create):

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -1,6 +1,5 @@
 import io
-from unittest import skip
-from django.test import Client, RequestFactory
+from django.test import Client, RequestFactory, SimpleTestCase
 from io import StringIO
 from registrar.decorators import allow_slow_queries
 from registrar.models import (
@@ -809,7 +808,6 @@ class MemberExportTest(MockDbForIndividualTests, MockEppLib):
         super().setUp()
         self.factory = RequestFactory()
 
-    @skip("flaky test that needs to be refactored")
     @less_console_noise_decorator
     def test_member_export(self):
         """Tests the member export report by comparing the csv output."""
@@ -872,40 +870,171 @@ class MemberExportTest(MockDbForIndividualTests, MockEppLib):
         # Reset the CSV file's position to the beginning
         csv_file.seek(0)
         # Read the content into a variable
-        csv_content = csv_file.read()
-        expected_content = (
-            # Header
-            "Email,Member role,Invited by,Joined date,Last active,Domain requests,"
-            "Members,Domains,Number domains assigned,Domain assignments\n"
-            # Content
-            "big_lebowski@dude.co,False,help@get.gov,2022-04-01,Invalid date,None,"
-            "Viewer,True,1,cdomain1.gov\n"
-            "cozy_staffuser@igorville.gov,True,help@get.gov,2022-04-01,2024-02-01,"
-            "Viewer Requester,Manager,False,0,\n"
-            "icy_superuser@igorville.gov,True,help@get.gov,2022-04-01,2024-02-01,"
-            "Viewer Requester,Manager,False,0,\n"
-            "meoward@rocks.com,False,big_lebowski@dude.co,2022-04-01,Invalid date,None,"
-            'Manager,True,2,"adomain2.gov,cdomain1.gov"\n'
-            "nonexistentmember_1@igorville.gov,False,help@get.gov,Unretrieved,Invited,"
-            "None,Manager,False,0,\n"
-            "nonexistentmember_2@igorville.gov,False,help@get.gov,Unretrieved,Invited,"
-            "None,Viewer,False,0,\n"
-            "nonexistentmember_3@igorville.gov,False,help@get.gov,Unretrieved,Invited,"
-            "Viewer,None,False,0,\n"
-            "nonexistentmember_4@igorville.gov,True,help@get.gov,Unretrieved,Invited,"
-            "Viewer Requester,Manager,False,0,\n"
-            "nonexistentmember_5@igorville.gov,True,help@get.gov,Unretrieved,Invited,"
-            "Viewer Requester,Manager,False,0,\n"
-            "tired_sleepy@igorville.gov,False,System,2022-04-01,Invalid date,Viewer,"
-            "None,False,0,\n"
-        )
-        # Normalize line endings and remove commas,
-        # spaces and leading/trailing whitespace
-        csv_content = csv_content.replace(",,", "").replace(",", "").replace(" ", "").replace("\r\n", "\n").strip()
-        expected_content = expected_content.replace(",,", "").replace(",", "").replace(" ", "").strip()
-        self.maxDiff = None
-        self.assertEqual(csv_content, expected_content)
+        reader = csv.reader(csv_file)
+        header, *data_rows = list(reader)
+        data_rows.sort(key=lambda r: r[0])
 
+        expected_header = [
+            "Email",
+            "Member role",
+            "Invited by",
+            "Joined date",
+            "Last active",
+            "Domain requests",
+            "Members",
+            "Domains",
+            "Number domains assigned",
+            "Domain assignments",
+        ]
+        # Content
+
+        expected_rows = [
+            [
+                "big_lebowski@dude.co",
+                "Basic",
+                "help@get.gov",
+                "2022-04-01",
+                "Invalid date",
+                "No access",
+                "Viewer",
+                "Viewer, limited",
+                "1",
+                "cdomain1.gov",
+            ],
+            [
+                "cozy_staffuser@igorville.gov",
+                "Organization admin",
+                "help@get.gov",
+                "2022-04-01",
+                "2024-02-01",
+                "Requester",
+                "Manager",
+                "Viewer",
+                "0",
+                "",
+            ],
+            [
+                "icy_superuser@igorville.gov",
+                "Organization admin",
+                "help@get.gov",
+                "2022-04-01",
+                "2024-02-01",
+                "Requester",
+                "Manager",
+                "Viewer",
+                "0",
+                "",
+            ],
+            [
+                "meoward@rocks.com",
+                "Basic",
+                "big_lebowski@dude.co",
+                "2022-04-01",
+                "Invalid date",
+                "No access",
+                "Manager",
+                "Viewer, limited",
+                "2",
+                "adomain2.gov, cdomain1.gov",
+            ],
+            [
+                "nonexistentmember_1@igorville.gov",
+                "Basic",
+                "help@get.gov",
+                "Unretrieved",
+                "Invited",
+                "No access",
+                "Manager",
+                "Viewer, limited",
+                "0",
+                "",
+            ],
+            [
+                "nonexistentmember_2@igorville.gov",
+                "Basic",
+                "help@get.gov",
+                "Unretrieved",
+                "Invited",
+                "No access",
+                "Viewer",
+                "Viewer, limited",
+                "0",
+                "",
+            ],
+            [
+                "nonexistentmember_3@igorville.gov",
+                "Basic",
+                "help@get.gov",
+                "Unretrieved",
+                "Invited",
+                "Viewer",
+                "No access",
+                "Viewer, limited",
+                "0",
+                "",
+            ],
+            [
+                "nonexistentmember_4@igorville.gov",
+                "Organization admin",
+                "help@get.gov",
+                "Unretrieved",
+                "Invited",
+                "Requester",
+                "Manager",
+                "Viewer",
+                "0",
+                "",
+            ],
+            [
+                "nonexistentmember_5@igorville.gov",
+                "Organization admin",
+                "help@get.gov",
+                "Unretrieved",
+                "Invited",
+                "Requester",
+                "Manager",
+                "Viewer",
+                "0",
+                "",
+            ],
+            [
+                "tired_sleepy@igorville.gov",
+                "Basic",
+                "System",
+                "2022-04-01",
+                "Invalid date",
+                "Viewer",
+                "No access",
+                "Viewer, limited",
+                "0",
+                "",
+            ],
+        ]
+
+        self.maxDiff = None
+        self.assertEqual(header, expected_header)
+        self.assertEqual(data_rows, expected_rows)
+
+
+class MemberExportNoneDomainInfoTest(SimpleTestCase):
+    """parse_row and write_csv when domain_info=None and unexpected errors."""
+
+    columns = [
+        "Email",
+        "Number domains assigned",
+        "Domain assignments",
+    ]
+
+    @less_console_noise_decorator
+    def test_parse_row_handles_none_domain_info(self):
+        model = {
+            "email_display": "a@example.gov",
+            "roles": [],
+            "additional_permissions_display": None,
+            "domain_info": None,
+        }
+        row = MemberExport.parse_row(self.columns, model)
+        self.assertEqual(row, ["a@example.gov", 0, ""])
 
 class HelperFunctions(MockDbForSharedTests):
     """This asserts that 1=1. Its limited usefulness lies in making sure the helper methods stay healthy."""

--- a/src/registrar/utility/csv_export.py
+++ b/src/registrar/utility/csv_export.py
@@ -35,6 +35,7 @@ from django.db.models import (
 from django.utils import timezone
 from django.db.models.functions import Concat, Coalesce, Cast
 from django.contrib.postgres.aggregates import ArrayAgg, StringAgg
+from django.contrib.postgres.fields import ArrayField
 from django.contrib.admin.models import LogEntry, ADDITION
 from django.contrib.contenttypes.models import ContentType
 from registrar.models.utility.generic_helper import convert_queryset_to_dict
@@ -377,12 +378,15 @@ class MemberExport(BaseExport):
                     default=Value(""),
                     output_field=CharField(),
                 ),
-                domain_info=ArrayAgg(
-                    F("user__permissions__domain__name"),
-                    distinct=True,
-                    # only include domains in portfolio
-                    filter=Q(user__permissions__domain__isnull=False)
-                    & Q(user__permissions__domain__domain_info__portfolio=portfolio),
+                domain_info=Coalesce(
+                    ArrayAgg(
+                        F("user__permissions__domain__name"),
+                        distinct=True,
+                        # only include domains in portfolio
+                        filter=Q(user__permissions__domain__isnull=False)
+                        & Q(user__permissions__domain__domain_info__portfolio=portfolio),
+                    ),
+                    Value([], output_field=ArrayField(CharField())),
                 ),
                 type=Value("member", output_field=CharField()),
                 joined_date=Func(F("created_at"), Value("YYYY-MM-DD"), function="to_char", output_field=CharField()),
@@ -413,8 +417,7 @@ class MemberExport(BaseExport):
                 last_active=Value("Invited", output_field=CharField()),
                 additional_permissions_display=F("additional_permissions"),
                 member_display=F("email"),
-                # Use ArrayRemove to return an empty list when no domain invitations are found
-                domain_info=domain_invitations,
+                domain_info=Coalesce(domain_invitations, Value([], output_field=ArrayField(CharField()))),
                 type=Value("invitedmember", output_field=CharField()),
                 joined_date=Value("Unretrieved", output_field=CharField()),
                 invited_by_user=cls.get_invited_by_query(
@@ -509,7 +512,7 @@ class MemberExport(BaseExport):
         """
         roles = model.get("roles", [])
         permissions = model.get("additional_permissions_display")
-        user_managed_domains = model.get("domain_info", [])
+        user_managed_domains = model.get("domain_info") or []
         length_user_managed_domains = len(user_managed_domains)
         FIELDS = {
             "Email": model.get("email_display"),

--- a/src/registrar/utility/csv_export.py
+++ b/src/registrar/utility/csv_export.py
@@ -378,15 +378,14 @@ class MemberExport(BaseExport):
                     default=Value(""),
                     output_field=CharField(),
                 ),
-                domain_info=Coalesce(
-                    ArrayAgg(
-                        F("user__permissions__domain__name"),
-                        distinct=True,
-                        # only include domains in portfolio
-                        filter=Q(user__permissions__domain__isnull=False)
-                        & Q(user__permissions__domain__domain_info__portfolio=portfolio),
-                    ),
-                    Value([], output_field=ArrayField(CharField())),
+                domain_info=ArrayAgg(
+                    F("user__permissions__domain__name"),
+                    distinct=True,
+                    # only include domains in portfolio
+                    filter=Q(user__permissions__domain__isnull=False)
+                    & Q(user__permissions__domain__domain_info__portfolio=portfolio),
+                    # Django v5.0+ an empty ArrayAgg returns NULL rather than [];
+                    default=Value([], output_field=ArrayField(CharField())),
                 ),
                 type=Value("member", output_field=CharField()),
                 joined_date=Func(F("created_at"), Value("YYYY-MM-DD"), function="to_char", output_field=CharField()),
@@ -417,6 +416,8 @@ class MemberExport(BaseExport):
                 last_active=Value("Invited", output_field=CharField()),
                 additional_permissions_display=F("additional_permissions"),
                 member_display=F("email"),
+                # when a member has no invitations / null,
+                # Coalesce normalizes to empty list for parse_row. 
                 domain_info=Coalesce(domain_invitations, Value([], output_field=ArrayField(CharField()))),
                 type=Value("invitedmember", output_field=CharField()),
                 joined_date=Value("Unretrieved", output_field=CharField()),

--- a/src/registrar/utility/csv_export.py
+++ b/src/registrar/utility/csv_export.py
@@ -417,7 +417,7 @@ class MemberExport(BaseExport):
                 additional_permissions_display=F("additional_permissions"),
                 member_display=F("email"),
                 # when a member has no invitations / null,
-                # Coalesce normalizes to empty list for parse_row. 
+                # Coalesce normalizes to empty list for parse_row.
                 domain_info=Coalesce(domain_invitations, Value([], output_field=ArrayField(CharField()))),
                 type=Value("invitedmember", output_field=CharField()),
                 joined_date=Value("Unretrieved", output_field=CharField()),

--- a/src/registrar/utility/csv_export.py
+++ b/src/registrar/utility/csv_export.py
@@ -2248,9 +2248,12 @@ class DomainRequestDataFull(DomainRequestExport):
             {
                 "requester_approved_domains_count": cls.get_requester_approved_domains_count_query(),
                 "requester_active_requests_count": cls.get_requester_active_requests_count_query(),
-                "all_current_websites": StringAgg("current_websites__website", delimiter=delimiter, distinct=True),
+                # default="" keeps the pre-Django-5.0 empty-string result when there are no rows
+                "all_current_websites": StringAgg(
+                    "current_websites__website", delimiter=delimiter, distinct=True, default=Value("")
+                ),
                 "all_alternative_domains": StringAgg(
-                    "alternative_domains__website", delimiter=delimiter, distinct=True
+                    "alternative_domains__website", delimiter=delimiter, distinct=True, default=Value("")
                 ),
                 # Coerce the other contacts object to "{first_name} {last_name} {email}"
                 "all_other_contacts": StringAgg(
@@ -2264,6 +2267,7 @@ class DomainRequestDataFull(DomainRequestExport):
                     ),
                     delimiter=delimiter,
                     distinct=True,
+                    default=Value(""),
                 ),
             }
         )


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #5046

## Changes

- Wrap the `domain_info` `ArrayAgg` and `Subquery` annotations in `Coalesce(...)` so empty results return `[]` instead of `None`.
- Guard the `parse_row` consumer with `model.get("domain_info") or []`.
- Unskipped and refactor `test_member_export` to parse the CSV, sort rows, and assert per row instead of comparing one large normalized string.
- Added `MemberExportNoneDomainInfoTest` 
- Added a seed for portfolio member and invitation with no domain assignments for manual repro.

## Context
The django.contrib.postgres.aggregates.`ArrayAgg`, `JSONBAgg`, and `StringAgg` aggregates no longer return `[]`, `[]`, and `''`, respectively, when there are no rows. Django v5.0+ returns `None` instead. (ref. [django release 5.0](https://docs.djangoproject.com/en/6.0/releases/5.0/))

## Setup
1. Run / load fixtures (will load and **log** which portfolio the empty info is in.
2. Assign yourself as and Admin of this ^ portfolio.
3. Go to Members > Export to CSV.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
