### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/clone-db.yaml
+++ b/.github/workflows/clone-db.yaml
@@ -19,6 +19,9 @@ env:
   SOURCE_ENVIRONMENT: stable
   
 
+permissions:
+  contents: read
+
 jobs:
   clone-database:
     runs-on: ubuntu-24.04

--- a/.github/workflows/createcachetable.yaml
+++ b/.github/workflows/createcachetable.yaml
@@ -40,6 +40,9 @@ on:
           - rh
           - sm
 
+permissions:
+  contents: read
+
 jobs:
   createcachetable:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-check-to-delete-domains.yaml
+++ b/.github/workflows/daily-check-to-delete-domains.yaml
@@ -16,6 +16,9 @@ on:
     # Runs daily at 14:30 UTC
     - cron: "30 14 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   upload-reports:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-clearsessions.yaml
+++ b/.github/workflows/daily-clearsessions.yaml
@@ -6,6 +6,9 @@ on:
     - cron: "18 6 * * *"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   clear-sessions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/clone-db.yaml`, `.github/workflows/createcachetable.yaml`, `.github/workflows/daily-check-to-delete-domains.yaml`, `.github/workflows/daily-clearsessions.yaml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.