### PR TITLE
#4763: Open a deletion modal when form 'Delete' button is clicked

### DIFF
--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -59,7 +59,7 @@ function switchFromInputToTextArea (element) {
         textArea.insertAdjacentElement('afterend', displayCharCount)
 }
 
-// Validation errors produces an inline error and a top-level error banner, Clear both. 
+// Validation errors produces an inline error and a top-level error banner, Clear both.
 function clearRecordErrors(scope){
     if(scope){
         scope.querySelectorAll(".usa-error-message").forEach(el => el.remove());
@@ -105,13 +105,13 @@ function openCancelModal(opener){
     document.getElementById("toggle-cancel-add-dnsrecord")?.setAttribute("data-opener", opener);
 }
 
-// fields, reused for both Add and Edit forms. 
+// fields, reused for both Add and Edit forms.
 const FIELD_SELECTOR = 'input:not([type="hidden"]), textarea';
 
 // Add: any non-empty field (type dropdown excluded) is unsaved. Edit: any field differing from its original.
 function formHasUnsavedChanges(form, isEditForm){
     if(!form) return false;
-    // A failed save uses the rejected values as the fields, so treat a visible error 
+    // A failed save uses the rejected values as the fields, so treat a visible error
     // as unsaved so cancel still confirms and resets.
     if(form.querySelector(".usa-error-message")) return true;
     return Array.from(form.querySelectorAll(`${FIELD_SELECTOR}, select`)).some(el => {
@@ -487,7 +487,6 @@ export function initDynamicDNSRecordFormFields() {
 
 export function initDeleteDnsRecord() {
     const table = document.getElementById("dnsrecords-table");
-    let focusElement = null
 
     table?.addEventListener("click", (e) => {
         const deleteBtn = e.target.closest(".js-dnsrecord-delete");
@@ -495,8 +494,8 @@ export function initDeleteDnsRecord() {
 
         const recordId = deleteBtn.dataset.recordId
         e.preventDefault()
-        focusElement = document.getElementById(`dnsrecord-edit-form-${ recordId }`) || deleteBtn;
-
+        
+        const focusElement = deleteBtn;
         const modal = document.getElementById("delete-dns-record-modal");
         const modalTrigger = document.getElementById("delete-dns-record-modal-trigger")
         openModal(modalTrigger, modal, focusElement);

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -384,14 +384,14 @@ export function initDynamicDNSRecordFormFields() {
 export function initDeleteDnsRecord() {
     const container = document.getElementById("dnsrecords-form-container");
 
-    // listen for click of delete button
+    // listen for click of delete button and open the modal
     container?.addEventListener("click", (e) => {
         const deleteBtn = e.target.closest(".js-dnsrecord-delete");
         if(!deleteBtn) return;
         openDeleteModal();
     });
 
-    // click the ghost trigger element to open modal
+    // clicks the ghost trigger element to open modal
     // (located outside htmx swapped response so listener can still find it)
     const openDeleteModal = () => {
         document.getElementById("delete-dns-record-modal-trigger")?.click();

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -380,3 +380,20 @@ export function initDynamicDNSRecordFormFields() {
         }
     )
 }
+
+export function initDeleteDnsRecord() {
+    const container = document.getElementById("dnsrecords-form-container");
+
+    // listen for click of delete button
+    container?.addEventListener("click", (e) => {
+        const deleteBtn = e.target.closest(".js-dnsrecord-delete");
+        if(!deleteBtn) return;
+        openDeleteModal();
+    });
+
+    // click the ghost trigger element to open modal
+    // (located outside htmx swapped response so listener can still find it)
+    const openDeleteModal = () => {
+        document.getElementById("delete-dns-record-modal-trigger")?.click();
+    }
+}

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -494,7 +494,7 @@ export function initDeleteDnsRecord() {
 
         const recordId = deleteBtn.dataset.recordId
         e.preventDefault()
-        
+
         const focusElement = deleteBtn;
         const modal = document.getElementById("delete-dns-record-modal");
         const modalTrigger = document.getElementById("delete-dns-record-modal-trigger")
@@ -516,6 +516,18 @@ export function initDeleteDnsRecord() {
                     }, 50);
                 }, { once: true });
             });
+
+            // Handle ESC key press to close modal --> move focus to focusElement
+            const handleEscKey = (e) => {
+                if (e.key === "Escape") {
+                    setTimeout(() => {
+                        focusElement?.focus();
+                    }, 50);
+                    document.removeEventListener("keydown", handleEscKey);
+                }
+            };
+
+            document.addEventListener("keydown", handleEscKey);
         }
         modalTrigger?.click()
     }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -383,16 +383,37 @@ export function initDynamicDNSRecordFormFields() {
 
 export function initDeleteDnsRecord() {
     const table = document.getElementById("dnsrecords-table");
+    let focusElement = null
 
     table?.addEventListener("click", (e) => {
         const deleteBtn = e.target.closest(".js-dnsrecord-delete");
         if(!deleteBtn) return;
 
+        const recordId = deleteBtn.dataset.recordId
         e.preventDefault()
-        openDeleteModal();
+        focusElement = document.getElementById(`dnsrecord-edit-form-${ recordId }`) || deleteBtn;
+
+        const modal = document.getElementById("delete-dns-record-modal");
+        const modalTrigger = document.getElementById("delete-dns-record-modal-trigger")
+        openModal(modalTrigger, modal, focusElement);
     });
 
-    const openDeleteModal = () => {
-        document.getElementById("delete-dns-record-modal-trigger")?.click();
+    const openModal = (modalTrigger, modal, focusElement) => {
+            // Listen for when the modal closes
+        if (modal) {
+            const closeButtons = modal.querySelectorAll("[data-close-modal]")
+
+            // targets the "X" and "Cancel" and moves focus to the focusElement after closing the modal
+            closeButtons.forEach(btn => {
+                btn.addEventListener("click", () => {
+                    // Defer focus restoration to after modal closes
+                    focusElement?.focus()
+                    setTimeout(() => {
+                        focusElement?.focus();
+                    }, 50);
+                }, { once: true });
+            });
+        }
+        modalTrigger?.click()
     }
 }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -382,17 +382,16 @@ export function initDynamicDNSRecordFormFields() {
 }
 
 export function initDeleteDnsRecord() {
-    const container = document.getElementById("dnsrecords-form-container");
+    const table = document.getElementById("dnsrecords-table");
 
-    // listen for click of delete button and open the modal
-    container?.addEventListener("click", (e) => {
+    table?.addEventListener("click", (e) => {
         const deleteBtn = e.target.closest(".js-dnsrecord-delete");
         if(!deleteBtn) return;
+
+        e.preventDefault()
         openDeleteModal();
     });
 
-    // clicks the ghost trigger element to open modal
-    // (located outside htmx swapped response so listener can still find it)
     const openDeleteModal = () => {
         document.getElementById("delete-dns-record-modal-trigger")?.click();
     }

--- a/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
+++ b/src/registrar/assets/src/js/getgov/domain-dns-record-content.js
@@ -403,7 +403,7 @@ export function initDeleteDnsRecord() {
         if (modal) {
             const closeButtons = modal.querySelectorAll("[data-close-modal]")
 
-            // targets the "X" and "Cancel" and moves focus to the focusElement after closing the modal
+            // targets the "X" and "Cancel" or "Go back" and moves focus to the focusElement after closing the modal
             closeButtons.forEach(btn => {
                 btn.addEventListener("click", () => {
                     // Defer focus restoration to after modal closes

--- a/src/registrar/assets/src/js/getgov/main.js
+++ b/src/registrar/assets/src/js/getgov/main.js
@@ -20,7 +20,7 @@ import { domain_purpose_choice_callbacks } from './domain-purpose-form.js';
 import { initButtonLinks } from '../getgov-admin/button-utils.js';
 import { initOrganizationsNavDropdown } from './organizations-dropdown.js';
 import { domainDeletionEventListener } from './domain-deletion-form.js';
-import { initDynamicDNSRecordFormFields, editAndCommentButtonListener, commentCharacterEventListener, initDNSRecordTabOrder, initDNSRecordAlertFocus } from './domain-dns-record-content.js';
+import { initDynamicDNSRecordFormFields, editAndCommentButtonListener, commentCharacterEventListener, initDNSRecordTabOrder, initDNSRecordAlertFocus, initDeleteDnsRecord } from './domain-dns-record-content.js';
 
 initDomainValidators();
 
@@ -83,5 +83,5 @@ document.addEventListener('htmx:afterSettle', (evt) => {
     commentCharacterEventListener()
 });
 
-
-
+// Init modals
+initDeleteDnsRecord();

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -52,7 +52,6 @@
                 <button
                     id="dnsrecord-delete-button-{{ record_id }}"
                     class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm usa-button--unstyled js-dnsrecord-delete"
-                    aria-controls="delete-dns-record-modal"
                     type="button"
                     role="button"
                     tabindex="0"

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -47,14 +47,14 @@
 
                 <button
                     id="dnsrecord-delete-button-{{ record_id }}"
-                    class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm usa-button--unstyled js-dnsrecord-delete"
+                    class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm usa-button--unstyled js-dnsrecord-delete display-flex flex-align-center"
                     type="button"
                     role="button"
                     tabindex="0"
                     data-action="form-delete"
                     data-record-id="{{ record_id }}"
                 >
-                    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                    <svg class="usa-icon margin-right-05" aria-hidden="true" focusable="false" role="img">
                         <use xlink:href="/public/img/sprite.svg#delete"></use>
                     </svg>
                     <span class="font-sans-sm">Delete</span>

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -49,29 +49,21 @@
                     Save
                 </button>
 
-                <a
+                <button
                     id="dnsrecord-delete-button-{{ record_id }}"
-                    class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm"
+                    class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm usa-button--unstyled js-dnsrecord-delete"
                     aria-controls="delete-dns-record-modal"
+                    type="button"
                     role="button"
                     tabindex="0"
                     data-action="form-delete"
                     data-record-id="{{ record_id }}"
-                    data-open-modal
                 >
                     <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
                         <use xlink:href="/public/img/sprite.svg#delete"></use>
                     </svg>
                     <span class="font-sans-sm">Delete</span>
-                </a>
-                <div
-                    class="usa-modal"
-                    id="delete-dns-record-modal"
-                    aria-labelledby="delete-dns-record-heading"
-                >
-                {% include 'includes/modal.html' with modal_heading_id="delete-dns-record-heading" modal_heading="Are you sure you want to delete this DNS record?" modal_description="This action cannot be undone." modal_button_id="delete-click-button" modal_button_text="Yes, delete" modal_button_class="usa-button--secondary" %}
-                </div>
-                <div class="margin-y-3">
+                </button>
             </form>
         </div>
     </td>

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -29,7 +29,7 @@
                     <!-- Hardcorded character limits for the comment field should be removed if/when the dns record model is updated -->
                     {{ 100|remaining_characters_text:dns_record.form.comment.value }}
                     </div>
-                    
+
                 </div>
                 <button
                     type="button"
@@ -50,18 +50,28 @@
                 </button>
 
                 <a
+                    id="dnsrecord-delete-button-{{ record_id }}"
                     class="margin-top-5 line-height-sans-5 text-secondary float-right font-sans-sm"
+                    aria-controls="delete-dns-record-modal"
                     role="button"
                     tabindex="0"
                     data-action="form-delete"
                     data-record-id="{{ record_id }}"
-                    aria-label="Delete DNS record from Cloudflare"
+                    data-open-modal
                 >
                     <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
                         <use xlink:href="/public/img/sprite.svg#delete"></use>
                     </svg>
                     <span class="font-sans-sm">Delete</span>
                 </a>
+                <div
+                    class="usa-modal"
+                    id="delete-dns-record-modal"
+                    aria-labelledby="delete-dns-record-heading"
+                >
+                {% include 'includes/modal.html' with modal_heading_id="delete-dns-record-heading" modal_heading="Are you sure you want to delete this DNS record?" modal_description="This action cannot be undone." modal_button_id="delete-click-button" modal_button_text="Yes, delete" modal_button_class="usa-button--secondary" %}
+                </div>
+                <div class="margin-y-3">
             </form>
         </div>
     </td>
@@ -74,7 +84,7 @@
              <span id="dns-comment-{{record_id}}-text">
                 <!-- added this span to swap the text when the form is updated with a new comment-->
                 {{ dns_record.comment }}
-             </span>   
+             </span>
           </div>
     </td>
 </tr>

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -9,7 +9,6 @@
                 id="dnsrecord-edit-form-{{ record_id }}"
                 method="post"
                 class="usa-form usa-form--extra-large"
-                tabindex="-1"
                 novalidate
                 hx-post="{% url 'domain-dns-records' domain.pk %}"
                 hx-target="#dnsrecord-edit-form-{{ record_id }}"

--- a/src/registrar/templates/domain_dns_record_edit_form.html
+++ b/src/registrar/templates/domain_dns_record_edit_form.html
@@ -9,6 +9,7 @@
                 id="dnsrecord-edit-form-{{ record_id }}"
                 method="post"
                 class="usa-form usa-form--extra-large"
+                tabindex="-1"
                 novalidate
                 hx-post="{% url 'domain-dns-records' domain.pk %}"
                 hx-target="#dnsrecord-edit-form-{{ record_id }}"

--- a/src/registrar/templates/domain_dns_record_row.html
+++ b/src/registrar/templates/domain_dns_record_row.html
@@ -80,7 +80,7 @@
                 <button
                     type="button"
                     class="usa-button usa-button--unstyled text-underline late-loading-modal-trigger margin-top-2 line-height-sans-5 text-secondary"
-                    aria-label="Delete DNS record from Cloudflare"
+                    aria-label="Delete DNS record"
                 >
                     Delete
                 </button>

--- a/src/registrar/templates/domain_dns_records.html
+++ b/src/registrar/templates/domain_dns_records.html
@@ -25,7 +25,7 @@
     {% include "includes/form_errors.html" with form=form %}
     <div id="dnsrecords-form-container">
         <h1>DNS records</h1>
-    
+
         <div class="grid-row">
             <div class="grid-col-12">
                 <p class="measure-none margin-top-0">
@@ -37,7 +37,7 @@
                 <div class="display-flex flex-align-center margin-top-4 margin-bottom-1">
                     <div class="grid-col">
                         <h2 class="margin-top-0 margin-bottom-0">Manage DNS records</h2>
-                    </div>        
+                    </div>
                     <div class="grid-col-auto">
                         <button
                             class="usa-button"
@@ -52,9 +52,9 @@
 
                 <div class="margin-bottom-5" x-cloak x-show="showFormId == 0">
                     {% include "includes/required_fields.html" %}
-                
+
                     <section class="border radius-lg border-base-lighter padding-3">
-                    <form 
+                    <form
                         class="usa-form usa-form--extra-large"
                         hx-post="{% url 'domain-dns-records' domain.pk %}"
                         hx-swap="innerHTML show:top"
@@ -71,7 +71,24 @@
              </div>
         </div>
     </div>
-    
+{% comment %} DNS record delete modal {% endcomment %}
+    {% comment %} Delete modal trigger with js listener
+    (needed outside of edit form b/c htmx swap of row removes listener when on delete button) {% endcomment %}
+    <a
+    id="delete-dns-record-modal-trigger"
+    href="#delete-dns-record-modal"
+    class="usa-button usa-button--outline margin-top-1 display-none"
+    aria-controls="delete-dns-record-modal"
+    data-open-modal
+    >Trigger delete dns record modal</a>
+    <div
+        class="usa-modal"
+        id="delete-dns-record-modal"
+        aria-labelledby="delete-dns-record-heading"
+    >
+        {% include 'includes/modal.html' with modal_heading_id="delete-dns-record-heading" modal_heading="Are you sure you want to delete this DNS record?" modal_description="This action cannot be undone." modal_button_id="delete-click-button" modal_button_text="Yes, delete" modal_button_class="usa-button--secondary" %}
+    </div>
+
     <div id="dns-records-table-container">
         {% include "domain_dns_records_table.html" %}
     </div>

--- a/src/registrar/templates/domain_dns_records.html
+++ b/src/registrar/templates/domain_dns_records.html
@@ -70,43 +70,8 @@
              </div>
         </div>
     </div>
-    {# Delete modal trigger with js listener (needed outside of edit form b/c htmx swap of row removes listener when on delete button) #}
-    <a
-    id="delete-dns-record-modal-trigger"
-    href="#delete-dns-record-modal"
-    class="usa-button usa-button--outline margin-top-1 display-none"
-    aria-controls="delete-dns-record-modal"
-    data-open-modal
-    >Trigger delete dns record modal</a>
-    
-    {# DNS record delete modal #}
-    <div
-        class="usa-modal"
-        id="delete-dns-record-modal"
-        aria-labelledby="delete-dns-record-heading"
-    >
-        {% include 'includes/modal.html' with modal_heading_id="delete-dns-record-heading" modal_heading="Are you sure you want to delete this DNS record?" modal_description="This action cannot be undone." modal_button_id="delete-click-button" modal_button_text="Yes, delete" modal_button_class="usa-button--secondary" %}
-    </div>
 
-
-    {# Shared modal for Add and Edit. USWDS relocates it to the page body on init, so it's driven by data attributes + JS (initDNSRecordCancelModal)#}
-    <div
-        class="usa-modal"
-        id="toggle-cancel-add-dnsrecord"
-        aria-labelledby="cancel-add-dnsrecord-heading"
-        aria-describedby="cancel-add-dnsrecord-description"
-    >
-        {% include 'includes/modal.html' with modal_heading="Are you sure you want to cancel your changes?" modal_description="You have unsaved changes that will be lost." modal_heading_id="cancel-add-dnsrecord-heading" modal_description_id="cancel-add-dnsrecord-description" modal_button_id="cancel-add-dnsrecord-confirm" modal_button_text="Yes, cancel" cancel_button_text="Go back" %}
-    </div>
-
-    {# Hidden USWDS opener for the modal. The JS clicks this vs anything htmx would re-render / swap #}
-    <a
-        id="open-cancel-add-dnsrecord-modal"
-        href="#toggle-cancel-add-dnsrecord"
-        class="display-none"
-        aria-controls="toggle-cancel-add-dnsrecord"
-        data-open-modal
-    >Open cancel confirmation modal</a>
+    {% include 'includes/domain_dns_records_modals_and_openers.html' %}
 
     <div id="dns-records-table-container">
         {% include "domain_dns_records_table.html" %}

--- a/src/registrar/templates/includes/domain_dns_records_modals_and_openers.html
+++ b/src/registrar/templates/includes/domain_dns_records_modals_and_openers.html
@@ -1,5 +1,4 @@
-{% load static url_helpers %}
-{# This file includes hidden USWDS modal openers and their respective modals.  The user clicks a button which triggers JS to click the opener vs anything htmx would re-render / swap. USWDS relocates it to the page body on init, so it's driven by data attributes + JS #}
+{# This file includes hidden USWDS modal openers (aka triggers) and their respective modals.  The user clicks a button which triggers JS to click the opener vs anything htmx would re-render / swap. USWDS relocates it to the page body on init, so it's driven by data attributes + JS #}
 
 {# DELETE modal opener #}
 <a

--- a/src/registrar/templates/includes/domain_dns_records_modals_and_openers.html
+++ b/src/registrar/templates/includes/domain_dns_records_modals_and_openers.html
@@ -1,0 +1,39 @@
+{% load static url_helpers %}
+{# This file includes hidden USWDS modal openers and their respective modals.  The user clicks a button which triggers JS to click the opener vs anything htmx would re-render / swap. USWDS relocates it to the page body on init, so it's driven by data attributes + JS #}
+
+{# DELETE modal opener #}
+<a
+id="delete-dns-record-modal-trigger"
+href="#delete-dns-record-modal"
+class="usa-button usa-button--outline margin-top-1 display-none"
+aria-controls="delete-dns-record-modal"
+data-open-modal
+>Trigger delete dns record modal</a>
+
+{# DELETE modal #}
+<div
+    class="usa-modal"
+    id="delete-dns-record-modal"
+    aria-labelledby="delete-dns-record-heading"
+>
+    {% include 'includes/modal.html' with modal_heading_id="delete-dns-record-heading" modal_heading="Are you sure you want to delete this DNS record?" modal_description="This action cannot be undone." modal_button_id="delete-click-button" modal_button_text="Yes, delete" modal_button_class="usa-button--secondary" %}
+</div>
+
+{# CANCEL modal opener #}
+<a
+    id="open-cancel-add-dnsrecord-modal"
+    href="#toggle-cancel-add-dnsrecord"
+    class="display-none"
+    aria-controls="toggle-cancel-add-dnsrecord"
+    data-open-modal
+>Open cancel confirmation modal</a>
+
+{# Shared CANCEL modal for Add and Edit #}
+<div
+    class="usa-modal"
+    id="toggle-cancel-add-dnsrecord"
+    aria-labelledby="cancel-add-dnsrecord-heading"
+    aria-describedby="cancel-add-dnsrecord-description"
+>
+    {% include 'includes/modal.html' with modal_heading="Are you sure you want to cancel your changes?" modal_description="You have unsaved changes that will be lost." modal_heading_id="cancel-add-dnsrecord-heading" modal_description_id="cancel-add-dnsrecord-description" modal_button_id="cancel-add-dnsrecord-confirm" modal_button_text="Yes, cancel" cancel_button_text="Go back" %}
+</div>

--- a/src/registrar/templates/includes/modal.html
+++ b/src/registrar/templates/includes/modal.html
@@ -1,12 +1,14 @@
 {% load static form_helpers url_helpers %}
 {% load custom_filters %}
-
+{% comment %}
+This includes the content of the modal. Template needs to be wrapped in a <div class="usa-modal" id="my-modal-id" </div>
+{% endcomment %}
 <div class="usa-modal__content">
     <div class="usa-modal__main">
-        <h2 class="usa-modal__heading">
+        <h2 class="usa-modal__heading" id={{modal_heading_id}}>
             {{ modal_heading }}
             {%if domain_name_modal is not None %}
-                <span class="string-wrap">           
+                <span class="string-wrap">
                     {{ domain_name_modal }}
                 </span>
             {%endif%}

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -520,7 +520,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
         content = response.content.decode()
 
         # All three markers must appear together on the form's Delete link.
-        self.assertContains(response, 'aria-label="Delete DNS record from Cloudflare"')
+        self.assertContains(response, 'aria-label="Delete DNS record"')
         self.assertContains(response, 'data-action="form-delete"')
         self.assertContains(response, f'data-record-id="{record.id}"')
         self.assertIn('role="button"', content)


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4763

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Adds a modal for dns deletion
- Opens the modal when the form's "Delete" button is clicked (the table row's delete will be set up in another issue)
- pulls modals and openers into their own file so as not to clutter dns records template

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
A simple aria-control worked without adding a hidden trigger anchor. However, when the row is rendered through an htmx response, it does not work because the DOM element listening for the 'click' is replaced and can no longer listen. Therefore, I included a trigger anchor located outside the form. The sequence of events:
User clicks Delete in form -->
a listener on the form clicks the <a> anchor outside the form (in the dns records page template) -->
 the anchor tells the modal to open

Since we are going to start including more modals on the page, I pulled the modals and openers (rn for cancel and delete) into their own template.

I have focus going to the Delete button if the modal is closed without deleting. 

We seem to be using two terms, "opener" and "trigger" (including myself) throughout the application (see `domain_nameservers.html`. Do we want to align? 

Setting up tests for opening and closing the modal felt like overkill, so I didn't add any. We'll definitely test deletion itself when implemented.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
**with a waffle flag on and an enterprise, enrolled domain**
- Go to the DNS records page
- Make a record
- WIthout refreshing, Click "Edit" on that record
- You should see the Delete record modal appear (note that the 'Yes, delete button' will be hooked up in another issue)
- Clicking "Cancel" or outside the modal or on the X closes the modal
- Refresh the page and ensure that the modal still opens and works as expected
- Ensure the modal still opens on each record when you have multiple records

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [x] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [x] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [x] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->

https://github.com/user-attachments/assets/f958bdaa-3ff7-4954-b1b6-1ddb546097da

