### PR TITLE
#4866: Make tooltips wrap at 320px [dg]

### DIFF
--- a/src/registrar/assets/src/js/getgov/table-domains.js
+++ b/src/registrar/assets/src/js/getgov/table-domains.js
@@ -46,7 +46,7 @@ export class DomainsTable extends BaseTable {
       <td data-label="Status">
         ${domain.state_display}
         <svg 
-        class="usa-icon usa-tooltip usa-tooltip--registrar text-middle margin-bottom-05 ${iconColor} no-click-outline-and-cursor-help" 
+        class="usa-icon usa-tooltip text-middle margin-bottom-05 ${iconColor} no-click-outline-and-cursor-help"
         data-position="top"
           title="${domain.get_state_help_text}"
           focusable="true"

--- a/src/registrar/assets/src/sass/_theme/_tooltips.scss
+++ b/src/registrar/assets/src/sass/_theme/_tooltips.scss
@@ -1,74 +1,32 @@
 @use "uswds-core" as *;
 
-// Only apply this custom wrapping to desktop
-@include at-media(desktop) {
-  .usa-tooltip--registrar .usa-tooltip__body {
-    width: 350px;
-    white-space: normal;
-    text-align: center;
-  }
-}
-
-@include at-media(tablet) {
-  .usa-tooltip--registrar .usa-tooltip__body {
-    width: 250px !important;
-    white-space: normal !important;
-    text-align: center !important;
-  }
-}
-
-@include at-media(mobile) {
-  .usa-tooltip--registrar .usa-tooltip__body {
-    width: 250px !important;
-    white-space: normal !important;
-    text-align: center !important;
-  }
+// USWDS tooltips don't wrap by default. 
+// 320px width per design guidance in #4866 (check comments).
+// Style USWDS's .usa-tooltip__body to wrap and center text, 
+// and to limit width to 320px (mobile breakpoint).
+.usa-tooltip__body {
+  width: max-content; // needed so tooltip does not carriage return after each word
+  max-width: units("mobile"); // 320px
+  white-space: normal;
+  text-align: center;
 }
 
 #extended-logo .usa-tooltip__body {
   font-weight: 400 !important;
 }
 
-.domains__table, .usa-table {
-  /*
-  Trick tooltips in the domains table to do 2 things...
-  1 - Shrink itself to a padded viewport window
-  (override width and wrapping properties in key areas to constrain tooltip size)
-  2 - NOT be clipped by the table's scrollable view
-  (Set tooltip position to "fixed", which prevents tooltip from being clipped by parent
-  containers. Fixed-position detection was added to uswds positioning logic to update positioning
-  calculations accordingly.)
-  */
+.usa-table {
+  // Keep tooltips from being clipped by scrollable table containers.
+  // The custom code in uswds-edited.js checks for position: fixed
+  // and, when found, places the tooltip using screen coordinates instead of
+  // coordinates relative to the table.
   .usa-tooltip__body {
-    white-space: inherit;
-    max-width: fit-content; // prevent adjusted widths from being larger than content
-    position: fixed; // prevents clipping by parent containers
+    position: fixed;
   }
-  /*
-  Override width adustments in this dynamically added class
-  (this is original to the javascript handler as a way to shrink tooltip contents within the viewport,
-  but is insufficient for our needs.  We cannot simply override its properties
-  because the logic surrounding its dynamic appearance in the DOM does not account
-  for parent containers (basically, this class isn't in the DOM when we need it).
-  Intercept .usa-tooltip__content instead and nullify the effects of
-  .usa-tooltip__body--wrap to prevent conflicts)
-  */
+  // Overwrite .usa-tooltip__body--wrap (added by uswds js as a fallback):
+  // its width: 100% would stretch a fixed tooltip to the viewport.
   .usa-tooltip__body--wrap {
-    min-width: inherit;
     width: inherit;
-  }
-  /*
-  Add width and wrapping to tooltip content in order to confine it to a smaller viewport window.
-  */
-  .usa-tooltip__content {
-    width: 50vw;
-    text-wrap: wrap;
-    text-align: center;
-    font-size: inherit; //inherit tooltip fontsize of .93rem
-    max-width: fit-content;
-    display: block;
-    @include at-media('desktop') {
-      width: 70vw;
-    }
+    min-width: inherit;
   }
 }

--- a/src/registrar/assets/src/sass/_theme/_tooltips.scss
+++ b/src/registrar/assets/src/sass/_theme/_tooltips.scss
@@ -9,10 +9,9 @@
   max-width: units("mobile"); // 320px
   white-space: normal;
   text-align: center;
-}
 
-#extended-logo .usa-tooltip__body {
-  font-weight: 400 !important;
+  font-weight: normal; // reset inherited text styling from where they sit
+  line-height: 1.5;
 }
 
 .usa-table {


### PR DESCRIPTION
## Ticket

Resolves #4866

## Changes

- Tooltips wrap at a max width of 320px (the USWDS `mobile` spacing token) with centered text, per design guidance in the ticket slack convo ref comments of ticket please.
- Replaced the tooltip width overrides in `_tooltips.scss` with a one rule on `.usa-tooltip__body`
- Kept the fixed-position rule that stops tooltips from being clipped by scrollable table containers
- Removed the unused `usa-tooltip--registrar` class from the domains table status icon

## Context for reviewers

Root cause: USWDS restructures tooltip markup at init. The tooltip body is inserted as a sibling of the trigger element, and custom classes like `usa-tooltip--registrar` stay on the trigger. The old rule `.usa-tooltip--registrar .usa-tooltip__body` is a descendant selector, so it never matched and tooltips fell back to the USWDS default of `white-space: pre` -- one long unwrapped line. The table-specific rules did apply, but they sized tooltips at 50-70vw, which is wider than most tooltip text on desktop, so that text also rendered on one line.

The new rule targets `.usa-tooltip__body` directly, so it applies regardless of where USWDS moves the classes. `width: max-content` is needed because a wrapping tooltip otherwise collapses to one word per line.

## Setup

- Go to the Domains page
- Hover over the info icon next to a domain's status
- The tooltip wraps at 320px with centered text (2 lines for the standard status help text)
- Tooltips on the member permissions matrix and the header logo follow the same sizing

**Mobile:**
<img width="426" height="130" alt="Screenshot 2026-07-14 at 9 16 29 AM" src="https://github.com/user-attachments/assets/38d036c5-9f44-4c8a-8f1e-5587a823fc16" />

**Reg:**
<img width="519" height="296" alt="Screenshot 2026-07-14 at 9 18 09 AM" src="https://github.com/user-attachments/assets/78367c78-9258-4e51-9e10-b597b70ee081" />

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
