### PR TITLE
#4950 Update DnsHostingError error mapping strings 

### DIFF
--- a/docs/developer/dns-error-handling.md
+++ b/docs/developer/dns-error-handling.md
@@ -47,15 +47,13 @@ When Cloudflare says "no," here's what it means:
 
 | What went wrong | Error name | User sees |
 |---|---|---|
-| Resource doesn't exist | `DNS_NOT_FOUND` | TBD |
-| Bad data | `DNS_VALIDATION_FAILED` | TBD |
-| Too many requests | `DNS_RATE_LIMIT_EXCEEDED` | TBD |
-| Permission denied | `DNS_AUTH_FAILED` | TBD |
-| Network problem | `DNS_UPSTREAM_TIMEOUT` | TBD |
-| Cloudflare down | `DNS_UPSTREAM_ERROR` | TBD |
-| Something unexpected | `DNS_UNKNOWN` | TBD |
-
-> "TBD" copy is finalized in [#4999](https://github.com/cisagov/manage.get.gov/issues/4999) (Product/Content owns the wording). This table is updated when those strings are approved.
+| Resource doesn't exist | `DNS_NOT_FOUND` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>.  |
+| Bad data | `DNS_VALIDATION_FAILED` | There’s something wrong with the DNS record information you provided. Please try again. If the problem persists, contact us for assistance. |
+| Too many requests | `DNS_RATE_LIMIT_EXCEEDED` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>. |
+| Permission denied | `DNS_AUTH_FAILED` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>. |
+| Network problem | `DNS_UPSTREAM_TIMEOUT` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>.  |
+| Cloudflare down | `DNS_UPSTREAM_ERROR` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>. |
+| Something unexpected | `DNS_UNKNOWN` | An unexpected error occurred: Please try again. If the problem persists, contact us for assistance and share this ID <request id>. |
 
 **Quick rule:** 4xx codes are the user's problem (they can fix it). 5xx codes are our problem (Cloudflare or network).
 
@@ -278,8 +276,6 @@ Two failure shapes from `httpx`:
 Adding a new status code is a line in the `_STATUS_TO_ERROR` dict. The helper is testable on its own — feed it a fake `HTTPStatusError` and assert the returned exception type and code.
 
 The service logs **once** here, at the point of failure, with the raw Cloudflare context (`upstream_status`, `error_code`, `cf_ray`, `zone_id`, etc.). `logger.exception(...)` attaches the full Python traceback. The middleware's ContextVars (`request_id`, `user_email`, `ip_address`, `request_path`) are merged into the same log line by the `JsonFormatter`, so a single log entry has the Cloudflare-side context *and* the request-side context. Nothing downstream needs to log again.
-
-> **Today vs. after #4924:** the `request_id` ContextVar is not wired up in the current code; [#4924](https://github.com/cisagov/manage.get.gov/issues/4924) deliver this. Until then the field stays empty on log lines. Also, `user_email`, `ip_address`, and `request_path` only populate in production environments — non-prod log lines show the `"Anonymous"` / `"Unknown IP"` defaults from `logging_context.py`. That gate stays in place after #4924 for privacy reasons.
 
 **Layer 2 — `DnsHostService` passes the typed exception through unchanged** (sub-ticket [#4922](https://github.com/cisagov/manage.get.gov/issues/4922)). The current try/except around the Cloudflare call is removed. Because Python propagates exceptions up the call stack automatically, removing the `try/except` is all it takes — the typed error from `CloudflareService` flows straight through `DnsHostService` and into the view.
 

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 from django.conf import settings
 
+from registrar.logging_context import get_user_log_context
 from registrar.utility.errors import (
     DnsHostingError,
     DnsHostingErrorCodes,
@@ -46,10 +47,13 @@ def _typed_dns_error(e: HTTPError, **context) -> DnsHostingError:
     if isinstance(e, HTTPStatusError):
         status = e.response.status_code
         details = _cf_error_detail(e.response)
+        request_id = get_user_log_context().get("request_id")
+
         ctx = {
             "cf_ray": e.response.headers.get("cf-ray"),
             "cf_error_code": details.get("cf_error_code"),
             "cf_error_message": details.get("cf_error_message"),
+            "request_id": request_id,
             **context,
         }
         log_only = {"response_body": e.response.text}

--- a/src/registrar/services/mock_cloudflare_service.py
+++ b/src/registrar/services/mock_cloudflare_service.py
@@ -509,13 +509,24 @@ class MockCloudflareService:
                 },
                 headers={"cf-ray": "BB12"},
             )
-        if record_name.startswith("error-400"):
+        if record_name.startswith("error-content"):
             return httpx.Response(
                 400,
                 json={
                     "result": None,
                     "success": False,
                     "errors": [{"code": 9007, "message": f"Content for {record_type} record is invalid."}],
+                    "messages": [],
+                },
+                headers={"cf-ray": "R2D2"},
+            )
+        if record_name.startswith("error-400"):
+            return httpx.Response(
+                400,
+                json={
+                    "result": None,
+                    "success": False,
+                    "errors": [{"code": 0000, "message": "Unidentified 400 error"}],
                     "messages": [],
                 },
                 headers={"cf-ray": "R2D2"},

--- a/src/registrar/services/mock_cloudflare_service.py
+++ b/src/registrar/services/mock_cloudflare_service.py
@@ -531,10 +531,28 @@ class MockCloudflareService:
                 },
                 headers={"cf-ray": "R2D2"},
             )
+        if record_name.startswith("error-401"):
+            return httpx.Response(
+                401,
+                # TBD what is returned by CF in json
+                headers={"cf-ray": "AARD"},
+            )
         if record_name.startswith("error-403"):
             return httpx.Response(
                 403,
                 json={"success": False, "errors": [{"code": 10000, "message": "Authentication error"}]},
                 headers={"cf-ray": "C3PO"},
+            )
+        if record_name.startswith("error-403"):
+            return httpx.Response(
+                404,
+                # TBD what is returned by CF in json
+                headers={"cf-ray": "C3PO"},
+            )
+        if record_name.startswith("error-429"):
+            return httpx.Response(
+                429,
+                # TBD what is returned by CF in json
+                headers={"cf-ray": "VARK"},
             )
         return httpx.Response(500)

--- a/src/registrar/services/mock_cloudflare_service.py
+++ b/src/registrar/services/mock_cloudflare_service.py
@@ -435,7 +435,7 @@ class MockCloudflareService:
         except Exception as e:
             logger.error(f"Failed to get record zone name using request URL: {e}.")
 
-    def _mock_cf_error_response(self, record_name: str, record_type: str) -> httpx.Response:
+    def _mock_cf_error_response(self, record_name: str, record_type: str) -> httpx.Response:  # noqa: C901
         """Return an error response for ``error-*`` record names. These represent actual CF error codes and messages"""
         if record_name.startswith("error-duplicate"):
             return httpx.Response(

--- a/src/registrar/tests/test_dns_hosting_error.py
+++ b/src/registrar/tests/test_dns_hosting_error.py
@@ -36,11 +36,12 @@ class TestDnsHostingError(TestCase):
                 self.assertEqual(exc.code, default_code)
 
     def test_message_resolves_from_error_mapping(self):
-        """A user-facing message is resolved from `_error_mapping` for every code."""
+        """A user-facing message is resolved from `_build_error_mapping` for every code."""
+        request_id = None
         for code in codes:
             with self.subTest(code=code.name):
                 exc = DnsHostingError(code=code)
-                self.assertEqual(exc.message, DnsHostingError._error_mapping[code])
+                self.assertEqual(exc.message, exc._build_error_mapping(request_id)[code])
                 self.assertEqual(str(exc), exc.message)
 
     def test_all_dns_hosting_error_codes_are_wired(self):

--- a/src/registrar/tests/test_dns_hosting_error.py
+++ b/src/registrar/tests/test_dns_hosting_error.py
@@ -44,6 +44,17 @@ class TestDnsHostingError(TestCase):
                 self.assertEqual(exc.message, exc._build_error_mapping(request_id)[code])
                 self.assertEqual(str(exc), exc.message)
 
+    def test_message_resolves_from_error_mapping_with_request_id(self):
+        """A user-facing message is resolved from `_build_error_mapping` for every code."""
+        request_id = "123EASYASABC"
+        for code in codes:
+            with self.subTest(code=code.name):
+                exc = DnsHostingError(code=code, context={"request_id": request_id})
+                self.assertEqual(exc.message, exc._build_error_mapping(request_id)[code])
+                self.assertEqual(str(exc), exc.message)
+                if code != codes.VALIDATION_FAILED:
+                    self.assertIn(request_id, exc.message)
+
     def test_all_dns_hosting_error_codes_are_wired(self):
         self.assertLessEqual(set(codes), set(_DNS_WIRE_CODES))
 

--- a/src/registrar/tests/views/test_domain_dns_record_and_form.py
+++ b/src/registrar/tests/views/test_domain_dns_record_and_form.py
@@ -18,6 +18,7 @@ from registrar.validations import (
     DNS_RECORD_NAME_CONFLICT_ERROR_MESSAGE,
     DNS_RECORD_A_NAME_CONFLICT_ERROR_MESSAGE,
     DNS_RECORD_PRIORITY_REQUIRED_ERROR_MESSAGE,
+    DUPLICATE_DNS_RECORD_ERROR_MESSAGE,
 )
 
 from registrar.tests.test_views import TestWithUser
@@ -613,7 +614,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, "You already entered this DNS record")
+            self.assertNotContains(response, DUPLICATE_DNS_RECORD_ERROR_MESSAGE)
             svc.update_dns_record.assert_called_once()
 
     @override_flag("dns_hosting", active=True)
@@ -756,7 +757,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "You already entered this DNS record")
+            self.assertContains(response, DUPLICATE_DNS_RECORD_ERROR_MESSAGE)
             svc.create_dns_record.assert_not_called()
 
     @override_flag("dns_hosting", active=True)
@@ -790,7 +791,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "You already entered this DNS record")
+            self.assertContains(response, DUPLICATE_DNS_RECORD_ERROR_MESSAGE)
             svc.create_dns_record.assert_not_called()
 
     @override_flag("dns_hosting", active=True)
@@ -827,7 +828,7 @@ class TestDomainDNSRecordsView(TestWithDNSRecordPermissions, WebTest):
             )
 
             self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "You already entered this DNS record")
+            self.assertContains(response, DUPLICATE_DNS_RECORD_ERROR_MESSAGE)
             self.assertNotContains(response, DNS_RECORD_PRIORITY_REQUIRED_ERROR_MESSAGE)
             svc.create_dns_record.assert_not_called()
 

--- a/src/registrar/utility/api_response_helpers.py
+++ b/src/registrar/utility/api_response_helpers.py
@@ -1,0 +1,7 @@
+def get_request_id(request) -> str | None:
+    """Read the per-request correlation ID that RequestLoggingMiddleware stashed.
+
+    Returns None if the middleware hasn't run (e.g., unit tests that don't
+    route through the middleware stack).
+    """
+    return getattr(request, "_dns_request_id", None) if request is not None else None

--- a/src/registrar/utility/api_response_helpers.py
+++ b/src/registrar/utility/api_response_helpers.py
@@ -1,7 +1,0 @@
-def get_request_id(request) -> str | None:
-    """Read the per-request correlation ID that RequestLoggingMiddleware stashed.
-
-    Returns None if the middleware hasn't run (e.g., unit tests that don't
-    route through the middleware stack).
-    """
-    return getattr(request, "_dns_request_id", None) if request is not None else None

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -377,8 +377,13 @@ class DnsHostingError(Exception):
         "An unexpected error occurred: Please try again. If the problem persists, "
         "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
     )
+    GENERIC_VALIDATION_ERROR_MESSAGE = (
+            "There’s something wrong with the DNS record information you provided. Please try again. "
+            "If the problem persists, "
+            "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
+        )
 
-    def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
+    def __init__(self, *, code=None, message=None, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
         self._explicit_message = message
         self.upstream_status = upstream_status
@@ -386,17 +391,13 @@ class DnsHostingError(Exception):
         super().__init__(self.message)
 
     def _build_error_mapping(self, request_id):
-        validation_msg = (
-            "There’s something wrong with the DNS record information you provided. Please try again. "
-            "If the problem persists, "
-            "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
-        )
+        validation_msg = self.GENERIC_VALIDATION_ERROR_MESSAGE
         cf_error_code = self.context.get("cf_error_code")
 
         if self.wire_code == "DNS_VALIDATION_FAILED" and cf_error_code:
-            validation_msg = _DNS_VALIDATION_MSG[cf_error_code] or validation_msg
+            validation_msg = _DNS_VALIDATION_MSG.get(cf_error_code) or validation_msg
 
-        error_msg = DnsHostingError.GENERIC_ERROR_MESSAGE
+        error_msg = self.GENERIC_ERROR_MESSAGE
         if request_id:
             error_msg = (
                 "An unexpected error occurred: Please try again. If the problem persists, "
@@ -413,7 +414,7 @@ class DnsHostingError(Exception):
             DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
             DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
         }
-    
+
     @property
     def message(self):
         if self._explicit_message:

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -2,7 +2,11 @@ import logging
 
 from enum import IntEnum
 from django.utils.safestring import mark_safe
-from registrar.validations import MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE, TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE, DUPLICATE_DNS_RECORD_ERROR_MESSAGE
+from registrar.validations import (
+    MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE,
+    TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE,
+    DUPLICATE_DNS_RECORD_ERROR_MESSAGE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -349,9 +353,11 @@ _DNS_WIRE_CODES = {
     DnsHostingErrorCodes.UNKNOWN: "DNS_UNKNOWN",
 }
 
+
 def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, context):
     # Module-level rebuilder so __reduce__ stays picklable by name.
     return cls(code=code, message=explicit_message, upstream_status=upstream_status, context=context)
+
 
 _DNS_VALIDATION_MSG = {
     # TODO: string values are temporary and to be replaced with approved content
@@ -362,38 +368,44 @@ _DNS_VALIDATION_MSG = {
     81053: "An A, AAAA, or CNAME record with that name already exists.",
     9007: "Content for record is invalid.",
 }
+
+
 class DnsHostingError(Exception):
     """Typed base exception for DNS-hosting failures."""
 
-    GENERIC_ERROR_MESSAGE = "An unexpected error occurred: Please try again. If the problem persists, "
-    '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
+    GENERIC_ERROR_MESSAGE = (
+        "An unexpected error occurred: Please try again. If the problem persists, "
+        "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
+    )
 
     def _build_error_mapping(self, request_id):
-        validation_msg = "There’s something wrong with the DNS record information you provided."
+        validation_msg = (
+            "There’s something wrong with the DNS record information you provided. Please try again. "
+            "If the problem persists, "
+            "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
+        )
         cf_error_code = self.context.get("cf_error_code")
+
         if self.wire_code == "DNS_VALIDATION_FAILED" and cf_error_code:
             validation_msg = _DNS_VALIDATION_MSG[cf_error_code] or validation_msg
 
         error_msg = DnsHostingError.GENERIC_ERROR_MESSAGE
-
         if request_id:
-            error_msg = "An unexpected error occurred: Please try again. If the problem persists, "
-            '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a>'
-            f"for assistance and share this ID {request_id}."
+            error_msg = (
+                "An unexpected error occurred: Please try again. If the problem persists, "
+                "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a>"
+                f"for assistance and share this ID {request_id}."
+            )
 
         return {
-        DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
-        DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(
-            f"{validation_msg} Please try again. If the problem persists, "
-            '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
-        ),
-        DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: mark_safe(error_msg),
-        DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
-        DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
-        DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
-        DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
+            DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
+            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(validation_msg),
+            DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: mark_safe(error_msg),
+            DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
+            DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
+            DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
+            DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
         }
-
 
     def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
@@ -404,12 +416,11 @@ class DnsHostingError(Exception):
 
     @property
     def message(self):
-        return self._explicit_message
-
-    def set_message(self, request_id):
-        """User-facing text: explicit caller message, else the code-level default."""
+        if self._explicit_message:
+            return self._explicit_message
+        request_id = self.context.get("request_id")
         error_mapping = self._build_error_mapping(request_id)
-        self._explicit_message = error_mapping.get(self.code) or DnsHostingError.GENERIC_ERROR_MESSAGE
+        return error_mapping.get(self.code) or DnsHostingError.GENERIC_ERROR_MESSAGE
 
     @property
     def wire_code(self):

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -368,23 +368,20 @@ class DnsHostingError(Exception):
             '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a>'
             f"for assistance and share this ID {request_id}."
 
-            return {
-            DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
-            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(
-                "There’s something wrong with the DNS record information you provided. Please try again."
-                "If the problem persists, "
-                '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
-            ),
-            DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: (
-                "You’re making changes too quickly. Please wait a moment and try again."
-            ),
-            DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
-            DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
-            DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
-            DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
+        return {
+        DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
+        DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(
+            "There’s something wrong with the DNS record information you provided. Please try again."
+            "If the problem persists, "
+            '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
+        ),
+        DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: mark_safe(error_msg),
+        DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
+        DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
+        DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
+        DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
         }
-        else:
-            Exception("Must build message with `request_id` using get_message")
+
 
     def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -358,15 +358,15 @@ def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, con
 class DnsHostingError(Exception):
     """Typed base exception for DNS-hosting failures."""
 
-    GENERIC_ERROR_MESSAGE = (
+    GENERIC_ERROR_MESSAGE = mark_safe(
         "An unexpected error occurred: Please try again. If the problem persists, "
         "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
-    )
-    GENERIC_VALIDATION_ERROR_MESSAGE = (
+    )  # nosec
+    GENERIC_VALIDATION_ERROR_MESSAGE = mark_safe(
         "There’s something wrong with the DNS record information you provided. Please try again. "
         "If the problem persists, "
         "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
-    )
+    )  # nosec
 
     def __init__(self, *, code=None, message=None, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
@@ -380,15 +380,13 @@ class DnsHostingError(Exception):
         error_msg = self.GENERIC_ERROR_MESSAGE
         if request_id:
             error_msg = format_html(
-                "An unexpected error occurred: Please try again. If the problem persists, "
-                "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a>"
-                " for assistance and share this ID {}.",
+                self.GENERIC_ERROR_MESSAGE[:-1] + " and share this ID {}.",
                 request_id,
-            )
+            )  # format_html also marks safe
 
         return {
             DnsHostingErrorCodes.NOT_FOUND: error_msg,
-            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(validation_msg),  # nosec
+            DnsHostingErrorCodes.VALIDATION_FAILED: validation_msg,
             DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: error_msg,
             DnsHostingErrorCodes.AUTH_FAILED: error_msg,
             DnsHostingErrorCodes.UPSTREAM_TIMEOUT: error_msg,

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -359,17 +359,6 @@ def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, con
     return cls(code=code, message=explicit_message, upstream_status=upstream_status, context=context)
 
 
-_DNS_VALIDATION_MSG = {
-    # TODO: string values are temporary and to be replaced with approved content
-    81058: DUPLICATE_DNS_RECORD_ERROR_MESSAGE,
-    9000: "DNS name is invalid.",
-    9015: TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE,
-    83011: MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE,
-    81053: "An A, AAAA, or CNAME record with that name already exists.",
-    9007: "Content for record is invalid.",
-}
-
-
 class DnsHostingError(Exception):
     """Typed base exception for DNS-hosting failures."""
 
@@ -378,10 +367,10 @@ class DnsHostingError(Exception):
         "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
     )
     GENERIC_VALIDATION_ERROR_MESSAGE = (
-            "There’s something wrong with the DNS record information you provided. Please try again. "
-            "If the problem persists, "
-            "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
-        )
+        "There’s something wrong with the DNS record information you provided. Please try again. "
+        "If the problem persists, "
+        "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
+    )
 
     def __init__(self, *, code=None, message=None, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
@@ -392,11 +381,6 @@ class DnsHostingError(Exception):
 
     def _build_error_mapping(self, request_id):
         validation_msg = self.GENERIC_VALIDATION_ERROR_MESSAGE
-        cf_error_code = self.context.get("cf_error_code")
-
-        if self.wire_code == "DNS_VALIDATION_FAILED" and cf_error_code:
-            validation_msg = _DNS_VALIDATION_MSG.get(cf_error_code) or validation_msg
-
         error_msg = self.GENERIC_ERROR_MESSAGE
         if request_id:
             error_msg = (

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -378,6 +378,13 @@ class DnsHostingError(Exception):
         "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a> for assistance."
     )
 
+    def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
+        self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
+        self._explicit_message = message
+        self.upstream_status = upstream_status
+        self.context = dict(context) if context else {}
+        super().__init__(self.message)
+
     def _build_error_mapping(self, request_id):
         validation_msg = (
             "There’s something wrong with the DNS record information you provided. Please try again. "
@@ -406,14 +413,7 @@ class DnsHostingError(Exception):
             DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
             DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
         }
-
-    def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
-        self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
-        self._explicit_message = message
-        self.upstream_status = upstream_status
-        self.context = dict(context) if context else {}
-        super().__init__(self.message)
-
+    
     @property
     def message(self):
         if self._explicit_message:

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -348,7 +348,6 @@ _DNS_WIRE_CODES = {
     DnsHostingErrorCodes.UNKNOWN: "DNS_UNKNOWN",
 }
 
-
 def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, context):
     # Module-level rebuilder so __reduce__ stays picklable by name.
     return cls(code=code, message=explicit_message, upstream_status=upstream_status, context=context)
@@ -357,23 +356,37 @@ def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, con
 class DnsHostingError(Exception):
     """Typed base exception for DNS-hosting failures."""
 
-    _error_mapping = {
-        DnsHostingErrorCodes.NOT_FOUND: (
-            "A resource was not found. Please try again. If the problem persists, contact us for assistance."
-        ),
-        DnsHostingErrorCodes.VALIDATION_FAILED: (
-            "The DNS record couldn’t be saved because one of its fields wasn’t valid."
-        ),
-        DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: (
-            "You’re making changes too quickly. Please wait a moment and try again."
-        ),
-        DnsHostingErrorCodes.AUTH_FAILED: ("We couldn’t reach our DNS provider. Please try again in a moment."),
-        DnsHostingErrorCodes.UPSTREAM_TIMEOUT: ("We couldn’t reach our DNS provider. Please try again in a moment."),
-        DnsHostingErrorCodes.UPSTREAM_ERROR: ("We couldn’t reach our DNS provider. Please try again in a moment."),
-        DnsHostingErrorCodes.UNKNOWN: ("Something went wrong while updating DNS. Please try again in a moment."),
-    }
+    GENERIC_ERROR_MESSAGE = "An unexpected error occurred: Please try again. If the problem persists, "
+    '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
 
-    def __init__(self, *, code=None, message=None, upstream_status=None, context=None):
+    def _build_error_mapping(self, request_id):
+
+        error_msg = DnsHostingError.GENERIC_ERROR_MESSAGE
+
+        if request_id:
+            error_msg = "An unexpected error occurred: Please try again. If the problem persists, "
+            '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a>'
+            f"for assistance and share this ID {request_id}."
+
+            return {
+            DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
+            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(
+                "There’s something wrong with the DNS record information you provided. Please try again."
+                "If the problem persists, "
+                '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
+            ),
+            DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: (
+                "You’re making changes too quickly. Please wait a moment and try again."
+            ),
+            DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
+            DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
+            DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
+            DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
+        }
+        else:
+            Exception("Must build message with `request_id` using get_message")
+
+    def __init__(self, *, code=None, message=GENERIC_ERROR_MESSAGE, upstream_status=None, context=None):
         self.code = code if code is not None else DnsHostingErrorCodes.UNKNOWN
         self._explicit_message = message
         self.upstream_status = upstream_status
@@ -382,10 +395,12 @@ class DnsHostingError(Exception):
 
     @property
     def message(self):
+        return self._explicit_message
+
+    def set_message(self, request_id):
         """User-facing text: explicit caller message, else the code-level default."""
-        if self._explicit_message:
-            return self._explicit_message
-        return self._error_mapping.get(self.code) or "DNS operation failed."
+        error_mapping = self._build_error_mapping(request_id)
+        self._explicit_message = error_mapping.get(self.code) or DnsHostingError.GENERIC_ERROR_MESSAGE
 
     @property
     def wire_code(self):

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -2,6 +2,7 @@ import logging
 
 from enum import IntEnum
 from django.utils.safestring import mark_safe
+from registrar.validations import MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE, TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE, DUPLICATE_DNS_RECORD_ERROR_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -352,7 +353,15 @@ def _rebuild_dns_hosting_error(cls, code, explicit_message, upstream_status, con
     # Module-level rebuilder so __reduce__ stays picklable by name.
     return cls(code=code, message=explicit_message, upstream_status=upstream_status, context=context)
 
-
+_DNS_VALIDATION_MSG = {
+    # TODO: string values are temporary and to be replaced with approved content
+    81058: DUPLICATE_DNS_RECORD_ERROR_MESSAGE,
+    9000: "DNS name is invalid.",
+    9015: TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE,
+    83011: MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE,
+    81053: "An A, AAAA, or CNAME record with that name already exists.",
+    9007: "Content for record is invalid.",
+}
 class DnsHostingError(Exception):
     """Typed base exception for DNS-hosting failures."""
 
@@ -360,6 +369,10 @@ class DnsHostingError(Exception):
     '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
 
     def _build_error_mapping(self, request_id):
+        validation_msg = "There’s something wrong with the DNS record information you provided."
+        cf_error_code = self.context.get("cf_error_code")
+        if self.wire_code == "DNS_VALIDATION_FAILED" and cf_error_code:
+            validation_msg = _DNS_VALIDATION_MSG[cf_error_code] or validation_msg
 
         error_msg = DnsHostingError.GENERIC_ERROR_MESSAGE
 
@@ -371,8 +384,7 @@ class DnsHostingError(Exception):
         return {
         DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
         DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(
-            "There’s something wrong with the DNS record information you provided. Please try again."
-            "If the problem persists, "
+            f"{validation_msg} Please try again. If the problem persists, "
             '<a class="usa-link" href="https://get.gov/contact/" target="_blank">contact us</a> for assistance.'
         ),
         DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: mark_safe(error_msg),

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -381,7 +381,7 @@ class DnsHostingError(Exception):
             error_msg = (
                 "An unexpected error occurred: Please try again. If the problem persists, "
                 "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a>"
-                f"for assistance and share this ID {request_id}."
+                f" for assistance and share this ID {request_id}."
             )
 
         return {

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -2,11 +2,6 @@ import logging
 
 from enum import IntEnum
 from django.utils.safestring import mark_safe
-from registrar.validations import (
-    MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE,
-    TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE,
-    DUPLICATE_DNS_RECORD_ERROR_MESSAGE,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -2,6 +2,7 @@ import logging
 
 from enum import IntEnum
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 logger = logging.getLogger(__name__)
 
@@ -378,20 +379,21 @@ class DnsHostingError(Exception):
         validation_msg = self.GENERIC_VALIDATION_ERROR_MESSAGE
         error_msg = self.GENERIC_ERROR_MESSAGE
         if request_id:
-            error_msg = (
+            error_msg = format_html(
                 "An unexpected error occurred: Please try again. If the problem persists, "
                 "<a class='usa-link' href='https://get.gov/contact/' target='_blank'>contact us</a>"
-                f" for assistance and share this ID {request_id}."
+                " for assistance and share this ID {}.",
+                request_id,
             )
 
         return {
-            DnsHostingErrorCodes.NOT_FOUND: mark_safe(error_msg),
-            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(validation_msg),
-            DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: mark_safe(error_msg),
-            DnsHostingErrorCodes.AUTH_FAILED: mark_safe(error_msg),
-            DnsHostingErrorCodes.UPSTREAM_TIMEOUT: mark_safe(error_msg),
-            DnsHostingErrorCodes.UPSTREAM_ERROR: mark_safe(error_msg),
-            DnsHostingErrorCodes.UNKNOWN: mark_safe(error_msg),
+            DnsHostingErrorCodes.NOT_FOUND: error_msg,
+            DnsHostingErrorCodes.VALIDATION_FAILED: mark_safe(validation_msg),  # nosec
+            DnsHostingErrorCodes.RATE_LIMIT_EXCEEDED: error_msg,
+            DnsHostingErrorCodes.AUTH_FAILED: error_msg,
+            DnsHostingErrorCodes.UPSTREAM_TIMEOUT: error_msg,
+            DnsHostingErrorCodes.UPSTREAM_ERROR: error_msg,
+            DnsHostingErrorCodes.UNKNOWN: error_msg,
         }
 
     @property

--- a/src/registrar/validations.py
+++ b/src/registrar/validations.py
@@ -74,7 +74,9 @@ MX_CONTENT_SPACES_ERROR_MESSAGE = "Enter the mail server without any spaces."
 TXT_RECORD_CONTENT_QUOTES_ERROR_MESSAGE = "Enter content using quotation marks at neither the beginning nor end."
 TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE = "Content must be no more than 4080 characters."
 HOSTNAME_CONTENT_TRAILING_NUMBER_ERROR_MESSAGE = "Enter content that ends with a domain name."
-DUPLICATE_DNS_RECORD_ERROR_MESSAGE = "You already entered this DNS record. DNS records must be unique."
+DUPLICATE_DNS_RECORD_ERROR_MESSAGE = "This DNS record is already associated with this domain. "
+"DNS records must be unique."
+
 
 
 def get_content_type_label_by_record_type(record_type):

--- a/src/registrar/validations.py
+++ b/src/registrar/validations.py
@@ -76,6 +76,7 @@ TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE = "Content must be no more than 4080
 HOSTNAME_CONTENT_TRAILING_NUMBER_ERROR_MESSAGE = "Enter content that ends with a domain name."
 DUPLICATE_DNS_RECORD_ERROR_MESSAGE = "This DNS record is already associated with this domain. "
 "DNS records must be unique."
+MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE = "Combined content length of records with this name and type must not exceed 8192 characters."
 
 
 

--- a/src/registrar/validations.py
+++ b/src/registrar/validations.py
@@ -76,8 +76,8 @@ TXT_RECORD_CONTENT_MAX_LENGTH_ERROR_MESSAGE = "Content must be no more than 4080
 HOSTNAME_CONTENT_TRAILING_NUMBER_ERROR_MESSAGE = "Enter content that ends with a domain name."
 DUPLICATE_DNS_RECORD_ERROR_MESSAGE = "This DNS record is already associated with this domain. "
 "DNS records must be unique."
-MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE = "Combined content length of records with this name and type must not exceed 8192 characters."
-
+MAX_COMBINED_CONTENT_LENGTH_ERROR_MESSAGE = "Combined content length of records with this name and "
+"type must not exceed 8192 characters."
 
 
 def get_content_type_label_by_record_type(record_type):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -39,6 +39,7 @@ from registrar.models import (
 )
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioRoleChoices
+from registrar.utility.api_response_helpers import get_request_id
 from registrar.utility.enums import DefaultEmail
 from registrar.utility.errors import (
     GenericError,
@@ -838,6 +839,7 @@ class DomainDNSRecordsView(DomainFormBaseView):
     def __init__(self):
         self.dns_record = None
         self.dns_host_service = DnsHostService()
+        self.request_id = None
 
     def _get_domain(self, request):
         """
@@ -847,6 +849,7 @@ class DomainDNSRecordsView(DomainFormBaseView):
         self.session = request.session
         self.object = self.get_object()
         self._update_session_with_domain()
+        self.request_id = get_request_id(request)
 
     def dispatch(self, request, *args, **kwargs):
         self._get_domain(
@@ -1112,6 +1115,7 @@ class DomainDNSRecordsView(DomainFormBaseView):
         except DnsHostingError as e:
             # temp log to show these values are available. Remove in #4892
             logger.error(f"wire_code: {e.wire_code}, upstream_status: {e.upstream_status}")
+            e.set_message(self.request_id)
             messages.error(request, e.message)
         except GenericError:
             return self._error_response(request, status=400)

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -838,7 +838,6 @@ class DomainDNSRecordsView(DomainFormBaseView):
     def __init__(self):
         self.dns_record = None
         self.dns_host_service = DnsHostService()
-        self.request_id = None
 
     def _get_domain(self, request):
         """
@@ -848,8 +847,6 @@ class DomainDNSRecordsView(DomainFormBaseView):
         self.session = request.session
         self.object = self.get_object()
         self._update_session_with_domain()
-        self.request_id = request.headers.get("X-Request-Id")
-        print(f"🙈 {self.request_id}")
 
     def dispatch(self, request, *args, **kwargs):
         self._get_domain(
@@ -1113,9 +1110,6 @@ class DomainDNSRecordsView(DomainFormBaseView):
                     is_first_record, record_id = self._handle_create(request, x_zone_id, form_record_data)
 
         except DnsHostingError as e:
-            # temp log to show these values are available. Remove in #4892
-            logger.error(f"wire_code: {e.wire_code}, upstream_status: {e.upstream_status}")
-            e.set_message(self.request_id)
             messages.error(request, e.message)
         except GenericError:
             return self._error_response(request, status=400)

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -39,7 +39,6 @@ from registrar.models import (
 )
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioRoleChoices
-from registrar.utility.api_response_helpers import get_request_id
 from registrar.utility.enums import DefaultEmail
 from registrar.utility.errors import (
     GenericError,
@@ -849,7 +848,8 @@ class DomainDNSRecordsView(DomainFormBaseView):
         self.session = request.session
         self.object = self.get_object()
         self._update_session_with_domain()
-        self.request_id = get_request_id(request)
+        self.request_id = request.headers.get("X-Request-Id")
+        print(f"🙈 {self.request_id}")
 
     def dispatch(self, request, *args, **kwargs):
         self._get_domain(


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4950

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Replaces placeholder messages with approved content from #4999. Restructures the mapping mechanism so that we can include a `request_id`

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

 To trigger various error responses using mock responses, ensure that `DNS_MOCK_EXTERNAL_APIS=True` (needs to be set in the sandbox).
"Magic" words to trigger error responses are found in the `MockCloudFlareService._mock_cf_error_response`:
`error-400` --> validation error
`error-403` --> auth error
`error-401` --> auth error
`error-429` --> rate limit exceeded
`error` --> 500 error

Though these would not be expected to be caught by CF since we are catching them in the form itself first (except for the combined max), but any of these 400 validation errors will result in the same message (for now- in the future we can set up custom messages mapped to the validation error code returned by CF). 
`error-duplicate`
`error-invalid-name`
`error-exceed-content-max`
`error-exceed-combined-content-max`
`error-name-conflict`
`error-content`


## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
